### PR TITLE
A11y fixes for signup and signin

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -8,10 +8,7 @@
 		<link rel="apple-touch-icon" sizes="180x180" href="/favicon/apple-touch-icon.png" />
 		<meta name="apple-mobile-web-app-title" content="Open WebUI" />
 		<link rel="manifest" href="/favicon/site.webmanifest" />
-		<meta
-			name="viewport"
-			content="width=device-width, initial-scale=1, viewport-fit=cover"
-		/>
+		<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
 		<meta name="theme-color" content="#171717" />
 		<meta name="robots" content="noindex,nofollow" />
 		<meta name="description" content="Open WebUI" />

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1900,7 +1900,8 @@
 				<svelte:element
 					this={mainContentId ? 'main' : 'div'}
 					id={mainContentId}
-					class="flex flex-col flex-auto z-10 w-full">
+					class="flex flex-col flex-auto z-10 w-full"
+				>
 					{#if $settings?.landingPageMode === 'chat' || createMessagesList(history.currentId).length > 0}
 						<div
 							class=" pb-2.5 flex flex-col justify-between w-full flex-auto overflow-auto h-0 max-w-full z-10 scrollbar-hidden"

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -223,11 +223,12 @@
 <TermsModal bind:show={$showChangelog} />
 
 {#if loaded}
-<a
-	href=#{mainContentId}
-	class="px-4 py-1.5 text-sm rounded-full bg-black hover:bg-gray-800 text-white dark:bg-white dark:text-black dark:hover:bg-gray-100 transition font-medium space-x-1 absolute -top-full -left-full focus:top-5 focus:left-5 z-1000">
-	Skip to main content
-</a>
+	<a
+		href="#{mainContentId}"
+		class="px-4 py-1.5 text-sm rounded-full bg-black hover:bg-gray-800 text-white dark:bg-white dark:text-black dark:hover:bg-gray-100 transition font-medium space-x-1 absolute -top-full -left-full focus:top-5 focus:left-5 z-1000"
+	>
+		Skip to main content
+	</a>
 {/if}
 <div class="app relative">
 	<div

--- a/src/routes/(app)/c/[id]/+page.svelte
+++ b/src/routes/(app)/c/[id]/+page.svelte
@@ -4,9 +4,7 @@
 
 	import Chat from '$lib/components/chat/Chat.svelte';
 	import Help from '$lib/components/layout/Help.svelte';
-
 </script>
-
 
 <Chat chatIdProp={$page.params.id} {mainContentId} />
 <Help />

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -445,7 +445,7 @@
 									src="{WEBUI_BASE_URL}/static/10x_ai.png"
 									class=" w-7 inline-block"
 									style="vertical-align: baseline;"
-									alt="10x logo"
+									alt="10x AI"
 								/>
 							</div>
 						</a>

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -181,7 +181,7 @@
 							}}
 						>
 							<div class="mb-1">
-								<div class=" text-2xl font-medium">
+								<h1 class=" text-2xl font-medium">
 									{#if $config?.onboarding ?? false}
 										{$i18n.t(`Get started with {{WEBUI_NAME}}`, { WEBUI_NAME: $WEBUI_NAME })}
 									{:else if mode === 'ldap'}
@@ -191,7 +191,7 @@
 									{:else}
 										{$i18n.t(`Sign up to {{WEBUI_NAME}}`, { WEBUI_NAME: $WEBUI_NAME })}
 									{/if}
-								</div>
+								</h1>
 
 								{#if $config?.onboarding ?? false}
 									<div class=" mt-1 text-xs font-medium text-gray-500">

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -264,7 +264,7 @@
 										<input
 											bind:value={password}
 											type="password"
-											class="my-0.5 w-full text-sm outline-1 border rounded p-2.5"
+											class="my-0.5 w-full text-sm outline-1 border rounded p-2.5 dark:text-slate-500"
 											placeholder={$i18n.t('Enter Your Password')}
 											autocomplete="current-password"
 											name="current-password"

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -147,7 +147,7 @@
 						crossorigin="anonymous"
 						src="{WEBUI_BASE_URL}/static/favicon.png"
 						class=" w-6 rounded-full"
-						alt="logo"
+						alt="G.S.A.I."
 					/>
 				</div>
 			</div>

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -207,7 +207,9 @@
 								<div class="flex flex-col mt-4">
 									{#if mode === 'signup'}
 										<div class="mb-2">
-											<div class=" text-sm font-medium text-left mb-1"><label for="fullname">{$i18n.t('Name')}</label></div>
+											<div class=" text-sm font-medium text-left mb-1">
+												<label for="fullname">{$i18n.t('Name')}</label>
+											</div>
 											<input
 												bind:value={name}
 												type="text"
@@ -222,7 +224,9 @@
 
 									{#if mode === 'ldap'}
 										<div class="mb-2">
-											<div class=" text-sm font-medium text-left mb-1"><label for="username">{$i18n.t('Username')}</label></div>
+											<div class=" text-sm font-medium text-left mb-1">
+												<label for="username">{$i18n.t('Username')}</label>
+											</div>
 											<input
 												bind:value={ldapUsername}
 												type="text"
@@ -236,7 +240,9 @@
 										</div>
 									{:else}
 										<div class="mb-2">
-											<div class=" text-sm font-medium text-left mb-1"><label for="email">{$i18n.t('Email')}</label></div>
+											<div class=" text-sm font-medium text-left mb-1">
+												<label for="email">{$i18n.t('Email')}</label>
+											</div>
 											<input
 												bind:value={email}
 												type="email"
@@ -251,7 +257,9 @@
 									{/if}
 
 									<div>
-										<div class=" text-sm font-medium text-left mb-1"><label for="current-password">{$i18n.t('Password')}</label></div>
+										<div class=" text-sm font-medium text-left mb-1">
+											<label for="current-password">{$i18n.t('Password')}</label>
+										</div>
 
 										<input
 											bind:value={password}

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -207,13 +207,14 @@
 								<div class="flex flex-col mt-4">
 									{#if mode === 'signup'}
 										<div class="mb-2">
-											<div class=" text-sm font-medium text-left mb-1">{$i18n.t('Name')}</div>
+											<div class=" text-sm font-medium text-left mb-1"><label for="fullname">{$i18n.t('Name')}</label></div>
 											<input
 												bind:value={name}
 												type="text"
 												class="my-0.5 w-full text-sm outline-none bg-transparent"
 												autocomplete="name"
 												placeholder={$i18n.t('Enter Your Full Name')}
+												id="fullname"
 												required
 											/>
 										</div>
@@ -221,7 +222,7 @@
 
 									{#if mode === 'ldap'}
 										<div class="mb-2">
-											<div class=" text-sm font-medium text-left mb-1">{$i18n.t('Username')}</div>
+											<div class=" text-sm font-medium text-left mb-1"><label for="username">{$i18n.t('Username')}</label></div>
 											<input
 												bind:value={ldapUsername}
 												type="text"
@@ -229,12 +230,13 @@
 												autocomplete="username"
 												name="username"
 												placeholder={$i18n.t('Enter Your Username')}
+												id="username"
 												required
 											/>
 										</div>
 									{:else}
 										<div class="mb-2">
-											<div class=" text-sm font-medium text-left mb-1">{$i18n.t('Email')}</div>
+											<div class=" text-sm font-medium text-left mb-1"><label for="email">{$i18n.t('Email')}</label></div>
 											<input
 												bind:value={email}
 												type="email"
@@ -242,13 +244,14 @@
 												autocomplete="email"
 												name="email"
 												placeholder={$i18n.t('Enter Your Email')}
+												id="email"
 												required
 											/>
 										</div>
 									{/if}
 
 									<div>
-										<div class=" text-sm font-medium text-left mb-1">{$i18n.t('Password')}</div>
+										<div class=" text-sm font-medium text-left mb-1"><label for="current-password">{$i18n.t('Password')}</label></div>
 
 										<input
 											bind:value={password}
@@ -257,6 +260,7 @@
 											placeholder={$i18n.t('Enter Your Password')}
 											autocomplete="current-password"
 											name="current-password"
+											id="current-password"
 											required
 										/>
 									</div>

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -213,7 +213,7 @@
 											<input
 												bind:value={name}
 												type="text"
-												class="my-0.5 w-full text-sm outline-none bg-transparent"
+												class="my-0.5 w-full text-sm outline-1 border rounded p-1"
 												autocomplete="name"
 												placeholder={$i18n.t('Enter Your Full Name')}
 												id="fullname"
@@ -230,7 +230,7 @@
 											<input
 												bind:value={ldapUsername}
 												type="text"
-												class="my-0.5 w-full text-sm outline-none bg-transparent"
+												class="my-0.5 w-full text-sm outline-1 border rounded p-2.5"
 												autocomplete="username"
 												name="username"
 												placeholder={$i18n.t('Enter Your Username')}
@@ -246,7 +246,7 @@
 											<input
 												bind:value={email}
 												type="email"
-												class="my-0.5 w-full text-sm outline-none bg-transparent"
+												class="my-0.5 w-full text-sm outline-1 border rounded p-2.5"
 												autocomplete="email"
 												name="email"
 												placeholder={$i18n.t('Enter Your Email')}
@@ -264,7 +264,7 @@
 										<input
 											bind:value={password}
 											type="password"
-											class="my-0.5 w-full text-sm outline-none bg-transparent"
+											class="my-0.5 w-full text-sm outline-1 border rounded p-2.5"
 											placeholder={$i18n.t('Enter Your Password')}
 											autocomplete="current-password"
 											name="current-password"
@@ -278,14 +278,14 @@
 								{#if $config?.features.enable_login_form || $config?.features.enable_ldap}
 									{#if mode === 'ldap'}
 										<button
-											class="bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 dark:hover:text-white transition w-full rounded-full font-medium text-sm py-2.5"
+											class="bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/25 dark:hover:bg-gray-100/50 dark:text-gray-300 dark:hover:text-white transition w-full rounded-full font-medium text-sm py-2.5"
 											type="submit"
 										>
 											{$i18n.t('Authenticate')}
 										</button>
 									{:else}
 										<button
-											class="bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 dark:hover:text-white transition w-full rounded-full font-medium text-sm py-2.5"
+											class="bg-sky-100 hover:bg-sky-700 hover:text-white dark:bg-sky-700 dark:hover:bg-sky-100 dark:text-white dark:hover:text-black transition w-full rounded-full font-medium text-sm py-2.5 border border-gray-500/25 dark:focus:border-white"
 											type="submit"
 										>
 											{mode === 'signin'
@@ -336,7 +336,7 @@
 							<div class="flex flex-col space-y-2">
 								{#if $config?.oauth?.providers?.google}
 									<button
-										class="flex justify-center items-center bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 dark:hover:text-white transition w-full rounded-full font-medium text-sm py-2.5"
+										class="flex justify-center items-center bg-gray-500 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 dark:hover:text-white transition w-full rounded-full font-medium text-sm py-2.5"
 										on:click={() => {
 											window.location.href = `${WEBUI_BASE_URL}/oauth/google/login`;
 										}}
@@ -386,7 +386,7 @@
 								{/if}
 								{#if $config?.oauth?.providers?.oidc}
 									<button
-										class="flex justify-center items-center bg-gray-700/5 hover:bg-gray-700/10 dark:bg-gray-100/5 dark:hover:bg-gray-100/10 dark:text-gray-300 dark:hover:text-white transition w-full rounded-full font-medium text-sm py-2.5"
+										class="flex justify-center items-center bg-gray-200 hover:bg-gray-700/10 dark:bg-gray-500/50 dark:hover:bg-gray-100 dark:text-sky-100 dark:hover:text-black transition w-full rounded-full font-medium text-sm py-2.5 border border-gray-500/25 dark:focus:border-white"
 										on:click={() => {
 											window.location.href = `${WEBUI_BASE_URL}/oauth/oidc/login`;
 										}}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -34,8 +34,8 @@ export default {
 				}
 			},
 			zIndex: {
-				'100': '100',
-				'1000': '1000'
+				100: '100',
+				1000: '1000'
 			},
 			padding: {
 				'safe-bottom': 'env(safe-area-inset-bottom)'


### PR DESCRIPTION
# Changelog Entry

### Description

- A handfull of a11y/508 fixes for the sign-up/sign-in page and form elements.

### Changed

- Created `label`s for each `input` and programmatically associated them using `for` and `id` attributes
- Changed faux heading into an `h1` for the page
- Updated `input` styling so the fields are more visible in light and dark modes.
- Updated `button` styling so these elements are more visible in light and dark modes (and on hover and focus)
- Updated `alt` attribute for onboarding logo image in the top left of the page
- Updated `alt` attribute for the powered by 10x logo image 

Remaining for this page:
- Make toast notification on error accessible (possibly use the `svelte-announce` area for these or work on updating the existing toast notifications to actually announce as `role=alert` as they do not announce at all right now. 
