### PR TITLE
address issue#174, remove release update info temporarily

### DIFF
--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -44,7 +44,7 @@
 	//import ChangelogModal from '$lib/components/ChangelogModal.svelte';
 	import TermsModal from '$lib/components/TermsModal.svelte';
 	import AccountPending from '$lib/components/layout/Overlay/AccountPending.svelte';
-	import UpdateInfoToast from '$lib/components/layout/UpdateInfoToast.svelte';
+	//import UpdateInfoToast from '$lib/components/layout/UpdateInfoToast.svelte';
 
 	const i18n = getContext('i18n');
 
@@ -295,6 +295,7 @@
 		{/if}
 	</div>
 </div>
+<!--
 {#if version && compareVersion(version.latest, version.current) && ($settings?.showUpdateToast ?? true)}
 	<div class=" absolute bottom-8 right-8 z-50" in:fade={{ duration: 100 }}>
 		<UpdateInfoToast
@@ -306,7 +307,7 @@
 		/>
 	</div>
 {/if}
-
+-->
 <style>
 	.loading {
 		display: inline-block;


### PR DESCRIPTION
# Changelog Entry

### Description

- address issue#174: temporarily remove release pop up

### Removed

- remove UpdateInfoToast section in layout.svelte. (currently just comment it out, please let me know if you prefer this section code to be removed completely or hide it based on flag)


  
