### PR TITLE
Datadog fastapi hooks

### DIFF
--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.0",
+  "version": "1.4.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"
@@ -108,22 +108,27 @@
     }
   ],
   "results": {
-    "backend/apps/webui/routers/auths.py": [
+    ".github/workflows/integration-test.yml": [
       {
         "type": "Secret Keyword",
-        "filename": "backend/apps/webui/routers/auths.py",
-        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "filename": ".github/workflows/integration-test.yml",
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
         "is_verified": false,
-        "line_number": 331
-      }
-    ],
-    "backend/constants.py": [
+        "line_number": 110
+      },
       {
         "type": "Secret Keyword",
-        "filename": "backend/constants.py",
-        "hashed_secret": "40c889477924de3df881960272cbeb7e62572a92",
+        "filename": ".github/workflows/integration-test.yml",
+        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
         "is_verified": false,
-        "line_number": 75
+        "line_number": 156
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": ".github/workflows/integration-test.yml",
+        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "is_verified": false,
+        "line_number": 184
       }
     ],
     "backend/open-webui-pipelines/examples/pipelines/rag/haystack_pipeline.py": [
@@ -144,73 +149,401 @@
         "line_number": 24
       }
     ],
+    "backend/open_webui/constants.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/open_webui/constants.py",
+        "hashed_secret": "713eab38133158b4277a08d0e8dce351dd3c99f5",
+        "is_verified": false,
+        "line_number": 65
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/open_webui/constants.py",
+        "hashed_secret": "40c889477924de3df881960272cbeb7e62572a92",
+        "is_verified": false,
+        "line_number": 78
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/open_webui/constants.py",
+        "hashed_secret": "c8e0df7d1544d6245931a22cde152fcee3ad3a09",
+        "is_verified": false,
+        "line_number": 79
+      }
+    ],
+    "backend/open_webui/migrations/versions/1af9b942657b_migrate_tags.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/open_webui/migrations/versions/1af9b942657b_migrate_tags.py",
+        "hashed_secret": "7562604bc982a9108af4b1495f1bed0b796cbedf",
+        "is_verified": false,
+        "line_number": 16
+      }
+    ],
+    "backend/open_webui/migrations/versions/242a2047eae0_update_chat_table.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/open_webui/migrations/versions/242a2047eae0_update_chat_table.py",
+        "hashed_secret": "2da44d0998510e76ca2185187d4f42d871f8b25f",
+        "is_verified": false,
+        "line_number": 16
+      }
+    ],
+    "backend/open_webui/migrations/versions/3781e22d8b01_update_message_table.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/open_webui/migrations/versions/3781e22d8b01_update_message_table.py",
+        "hashed_secret": "eb5bf41a8caaeba4f917ec81b150cf9aef71202a",
+        "is_verified": false,
+        "line_number": 12
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/open_webui/migrations/versions/3781e22d8b01_update_message_table.py",
+        "hashed_secret": "068e88fb23c00de52a44953d6c89892c5d19fdaf",
+        "is_verified": false,
+        "line_number": 13
+      }
+    ],
+    "backend/open_webui/migrations/versions/3ab32c4b8f59_update_tags.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/open_webui/migrations/versions/3ab32c4b8f59_update_tags.py",
+        "hashed_secret": "c00f63be1ff697bb765cd5e677e2a224c1c285bd",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/open_webui/migrations/versions/3ab32c4b8f59_update_tags.py",
+        "hashed_secret": "7562604bc982a9108af4b1495f1bed0b796cbedf",
+        "is_verified": false,
+        "line_number": 17
+      }
+    ],
+    "backend/open_webui/migrations/versions/4ace53fd72c8_update_folder_table_datetime.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/open_webui/migrations/versions/4ace53fd72c8_update_folder_table_datetime.py",
+        "hashed_secret": "30335a6df4fc580ba68418a16d6bac5ef23fa198",
+        "is_verified": false,
+        "line_number": 12
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/open_webui/migrations/versions/4ace53fd72c8_update_folder_table_datetime.py",
+        "hashed_secret": "00534a2902bc0f7a6159ef2cf94f8f6fff6e1d25",
+        "is_verified": false,
+        "line_number": 13
+      }
+    ],
+    "backend/open_webui/migrations/versions/6a39f3d8e55c_add_knowledge_table.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/open_webui/migrations/versions/6a39f3d8e55c_add_knowledge_table.py",
+        "hashed_secret": "2da44d0998510e76ca2185187d4f42d871f8b25f",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "backend/open_webui/migrations/versions/7826ab40b532_update_file_table.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/open_webui/migrations/versions/7826ab40b532_update_file_table.py",
+        "hashed_secret": "068e88fb23c00de52a44953d6c89892c5d19fdaf",
+        "is_verified": false,
+        "line_number": 12
+      }
+    ],
+    "backend/open_webui/migrations/versions/7e5b5dc7342b_init.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/open_webui/migrations/versions/7e5b5dc7342b_init.py",
+        "hashed_secret": "3221694687bf422b502afb62d04ecf3ea932b691",
+        "is_verified": false,
+        "line_number": 19
+      }
+    ],
+    "backend/open_webui/migrations/versions/922e7a387820_add_group_table.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/open_webui/migrations/versions/922e7a387820_add_group_table.py",
+        "hashed_secret": "30335a6df4fc580ba68418a16d6bac5ef23fa198",
+        "is_verified": false,
+        "line_number": 13
+      }
+    ],
+    "backend/open_webui/migrations/versions/af906e964978_add_feedback_table.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/open_webui/migrations/versions/af906e964978_add_feedback_table.py",
+        "hashed_secret": "00534a2902bc0f7a6159ef2cf94f8f6fff6e1d25",
+        "is_verified": false,
+        "line_number": 13
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/open_webui/migrations/versions/af906e964978_add_feedback_table.py",
+        "hashed_secret": "51ab0a50090fbfcb22f7c98e3677dd16a50e915a",
+        "is_verified": false,
+        "line_number": 14
+      }
+    ],
+    "backend/open_webui/migrations/versions/c29facfe716b_update_file_table_path.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/open_webui/migrations/versions/c29facfe716b_update_file_table_path.py",
+        "hashed_secret": "51ab0a50090fbfcb22f7c98e3677dd16a50e915a",
+        "is_verified": false,
+        "line_number": 16
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/open_webui/migrations/versions/c29facfe716b_update_file_table_path.py",
+        "hashed_secret": "6e188d5ad3cd07d148af4db7d1844992bc282aea",
+        "is_verified": false,
+        "line_number": 17
+      }
+    ],
+    "backend/open_webui/migrations/versions/c69f45358db4_add_folder_table.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/open_webui/migrations/versions/c69f45358db4_add_folder_table.py",
+        "hashed_secret": "6e188d5ad3cd07d148af4db7d1844992bc282aea",
+        "is_verified": false,
+        "line_number": 12
+      },
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/open_webui/migrations/versions/c69f45358db4_add_folder_table.py",
+        "hashed_secret": "c00f63be1ff697bb765cd5e677e2a224c1c285bd",
+        "is_verified": false,
+        "line_number": 13
+      }
+    ],
+    "backend/open_webui/migrations/versions/ca81bd47c050_add_config_table.py": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/open_webui/migrations/versions/ca81bd47c050_add_config_table.py",
+        "hashed_secret": "aa7fcb17dadd8fca462106526d225c03090c28ef",
+        "is_verified": false,
+        "line_number": 15
+      }
+    ],
+    "backend/open_webui/retrieval/web/testdata/google_pse.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/open_webui/retrieval/web/testdata/google_pse.json",
+        "hashed_secret": "c4bef62c7a2edbb24254840b6f83176b8e83debd",
+        "is_verified": false,
+        "line_number": 18
+      },
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "backend/open_webui/retrieval/web/testdata/google_pse.json",
+        "hashed_secret": "1d9340a015d95da94231025a4e4555fe55256dc6",
+        "is_verified": false,
+        "line_number": 429
+      }
+    ],
+    "backend/open_webui/retrieval/web/testdata/searchapi.json": [
+      {
+        "type": "Base64 High Entropy String",
+        "filename": "backend/open_webui/retrieval/web/testdata/searchapi.json",
+        "hashed_secret": "fee60bf5cc881c14020a4d16a793468489bbe8d1",
+        "is_verified": false,
+        "line_number": 3
+      }
+    ],
+    "backend/open_webui/retrieval/web/testdata/serpstack.json": [
+      {
+        "type": "Hex High Entropy String",
+        "filename": "backend/open_webui/retrieval/web/testdata/serpstack.json",
+        "hashed_secret": "b61139d85e81f1b0012d1a352ee2a292d18b5565",
+        "is_verified": false,
+        "line_number": 26
+      }
+    ],
+    "backend/open_webui/routers/auths.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/open_webui/routers/auths.py",
+        "hashed_secret": "d033e22ae348aeb5660fc2140aec35850c4da997",
+        "is_verified": false,
+        "line_number": 332
+      }
+    ],
+    "backend/open_webui/test/apps/webui/routers/test_auths.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/open_webui/test/apps/webui/routers/test_auths.py",
+        "hashed_secret": "e9e4a6d29515c8e53e4df7bc6646a23237b8f862",
+        "is_verified": false,
+        "line_number": 63
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/open_webui/test/apps/webui/routers/test_auths.py",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 88
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/open_webui/test/apps/webui/routers/test_auths.py",
+        "hashed_secret": "2aa60a8ff7fcd473d321e0146afd9e26df395147",
+        "is_verified": false,
+        "line_number": 126
+      }
+    ],
+    "backend/open_webui/test/util/abstract_integration_test.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/open_webui/test/util/abstract_integration_test.py",
+        "hashed_secret": "c3499c2729730a7f807efb8676a92dcb6f8a3f8f",
+        "is_verified": false,
+        "line_number": 75
+      }
+    ],
+    "backend/open_webui/utils/test_oauth_manager.py": [
+      {
+        "type": "Secret Keyword",
+        "filename": "backend/open_webui/utils/test_oauth_manager.py",
+        "hashed_secret": "1089adfb1f11b95df31344030507912b5abdf57a",
+        "is_verified": false,
+        "line_number": 44
+      }
+    ],
     "cypress/support/e2e.ts": [
       {
         "type": "Secret Keyword",
         "filename": "cypress/support/e2e.ts",
         "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 6
+        "line_number": 8
       }
     ],
-    "docker-compose.yml": [
+    "src/lib/components/admin/Settings/WebSearch.svelte": [
       {
-        "type": "Secret Keyword",
-        "filename": "docker-compose.yml",
-        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/components/admin/Settings/WebSearch.svelte",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
         "is_verified": false,
-        "line_number": 8
+        "line_number": 384
+      }
+    ],
+    "src/lib/i18n/locales/ar-BH/translation.json": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/ar-BH/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      }
+    ],
+    "src/lib/i18n/locales/bg-BG/translation.json": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/bg-BG/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      }
+    ],
+    "src/lib/i18n/locales/bn-BD/translation.json": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/bn-BD/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       }
     ],
     "src/lib/i18n/locales/ca-ES/translation.json": [
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/ca-ES/translation.json",
-        "hashed_secret": "44dbb3657a67f916682e00b9069d4b72e037da2f",
+        "hashed_secret": "af1de6d37993ce6aa5441de6ced8125bfca1fd4a",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/ca-ES/translation.json",
-        "hashed_secret": "217bd89b265fb28cfe1b0c8ad51e9429aa0c5193",
+        "hashed_secret": "bff65497a175769c18e35567ccaa3f7ae8d8d5e2",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 186
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/ca-ES/translation.json",
-        "hashed_secret": "0c60d2f5b480285d48df331c67f057ad3ee55411",
+        "hashed_secret": "f8b12babea8cb348d5903b68b35601148d695dc0",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 188
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/ca-ES/translation.json",
-        "hashed_secret": "12beb1456378f4ef87bc9d5bdf2b4bc66999d3d5",
+        "hashed_secret": "7ba339f124bac8f79586a084d0862adf3badf3b9",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 225
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/ca-ES/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/ca-ES/translation.json",
-        "hashed_secret": "81c17248cb58aec9bcd7329497ed0f59e393efa1",
+        "hashed_secret": "a0b26420576f52b64eb9d7899277677d1e611bdc",
         "is_verified": false,
-        "line_number": 330
+        "line_number": 376
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ca-ES/translation.json",
+        "hashed_secret": "9fa50f12d5352175d583c281551906d2ca29a0c6",
+        "is_verified": false,
+        "line_number": 380
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ca-ES/translation.json",
+        "hashed_secret": "2e97b60f43030e0a717293e67e026b6c6298d04d",
+        "is_verified": false,
+        "line_number": 381
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ca-ES/translation.json",
+        "hashed_secret": "57b00ed490349243e76fb994f84e3318d11202ff",
+        "is_verified": false,
+        "line_number": 615
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/ca-ES/translation.json",
         "hashed_secret": "c12b9cac8e7cc55d8f2e19e8806205e6fe7d67b8",
         "is_verified": false,
-        "line_number": 367
+        "line_number": 683
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/ca-ES/translation.json",
-        "hashed_secret": "b344f77c588ccb1e8d7cb8eed5772ac57f32bd4a",
+        "hashed_secret": "916d1244842c1e83e0bae320b4d0bb1e59b6e876",
         "is_verified": false,
-        "line_number": 541
+        "line_number": 973
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ca-ES/translation.json",
+        "hashed_secret": "ed21401a4f3b94b6a4874dca72d06d2b9af2feac",
+        "is_verified": false,
+        "line_number": 978
       }
     ],
     "src/lib/i18n/locales/ceb-PH/translation.json": [
@@ -219,93 +552,251 @@
         "filename": "src/lib/i18n/locales/ceb-PH/translation.json",
         "hashed_secret": "30d9ce3f3bf174bc29d7953d8ad73609863f3731",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/ceb-PH/translation.json",
         "hashed_secret": "988542db8602f6677aa3f6c7d89e507403940767",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 186
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/ceb-PH/translation.json",
         "hashed_secret": "fe9ea82c23526c0923287b3d2c486d7d47969041",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 225
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/ceb-PH/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/ceb-PH/translation.json",
         "hashed_secret": "940818c6f9574822bf8b0ae12bfeeff79ba48738",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 381
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/ceb-PH/translation.json",
         "hashed_secret": "dc806fa739d15f84c445ca61c95d009f53b05a74",
         "is_verified": false,
-        "line_number": 330
+        "line_number": 615
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/ceb-PH/translation.json",
         "hashed_secret": "8be3c943b1609fffbfc51aad666d0a04adf83c9d",
         "is_verified": false,
-        "line_number": 367
+        "line_number": 683
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/ceb-PH/translation.json",
         "hashed_secret": "96d8960500da56c978c209069036791ce1984baf",
         "is_verified": false,
-        "line_number": 540
+        "line_number": 978
+      }
+    ],
+    "src/lib/i18n/locales/cs-CZ/translation.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/cs-CZ/translation.json",
+        "hashed_secret": "7624d8941173d80bb7e96b99033a9938b42bf682",
+        "is_verified": false,
+        "line_number": 130
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/cs-CZ/translation.json",
+        "hashed_secret": "17015cf3e1e2a920b807e3b9685eebdd70a08942",
+        "is_verified": false,
+        "line_number": 186
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/cs-CZ/translation.json",
+        "hashed_secret": "13b8fbbd425e44b0bfff3225c5db5d2cce1113cf",
+        "is_verified": false,
+        "line_number": 225
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/cs-CZ/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/cs-CZ/translation.json",
+        "hashed_secret": "18b6c6f858ba47b780b58a86bb844374a862c9f7",
+        "is_verified": false,
+        "line_number": 381
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/cs-CZ/translation.json",
+        "hashed_secret": "487b683fd092e69674ad9518e6d454b5f5883f64",
+        "is_verified": false,
+        "line_number": 615
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/cs-CZ/translation.json",
+        "hashed_secret": "894f36e5fe639267301de83d341819acc0a14d4b",
+        "is_verified": false,
+        "line_number": 683
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/cs-CZ/translation.json",
+        "hashed_secret": "7660e5355404b79a4b248caa298221b8d063dcc1",
+        "is_verified": false,
+        "line_number": 978
+      }
+    ],
+    "src/lib/i18n/locales/da-DK/translation.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/da-DK/translation.json",
+        "hashed_secret": "67cf369d2491392eb262404303379ad4e029efe5",
+        "is_verified": false,
+        "line_number": 130
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/da-DK/translation.json",
+        "hashed_secret": "4b93b7181ef4aed6f8b7f279b61d705a70c7eb77",
+        "is_verified": false,
+        "line_number": 186
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/da-DK/translation.json",
+        "hashed_secret": "36e9d041b65aa0dafc37914405b440c62af91cbe",
+        "is_verified": false,
+        "line_number": 225
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/da-DK/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/da-DK/translation.json",
+        "hashed_secret": "cbe12d18664bdfa7420e16461f8a710338229798",
+        "is_verified": false,
+        "line_number": 381
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/da-DK/translation.json",
+        "hashed_secret": "0303f9ae93c443f0080210fc14a4f28ef1894840",
+        "is_verified": false,
+        "line_number": 615
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/da-DK/translation.json",
+        "hashed_secret": "2ea63c64a46bcb4da9bb80b5c4d3c2c5b332c11f",
+        "is_verified": false,
+        "line_number": 683
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/da-DK/translation.json",
+        "hashed_secret": "629e7788f0c60d2fa26f6ebcb555dd5ab9f2ed80",
+        "is_verified": false,
+        "line_number": 978
       }
     ],
     "src/lib/i18n/locales/de-DE/translation.json": [
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/de-DE/translation.json",
+        "hashed_secret": "bafe18c16b229e438508f159c5ce7fb95940c07b",
+        "is_verified": false,
+        "line_number": 76
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/de-DE/translation.json",
         "hashed_secret": "fc577f211bd35093e4895b463caa53436fff1c96",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/de-DE/translation.json",
         "hashed_secret": "478b138fb0ae8fce12f93f045bcca383eedc777d",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 186
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/de-DE/translation.json",
         "hashed_secret": "f562caab01134c53120bd36dcda6d9d904760138",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 225
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/de-DE/translation.json",
-        "hashed_secret": "0719708d1cc814839bd818fdc27d446652f03383",
+        "hashed_secret": "80dac99f49c9cf45b55e31c0b49e260e37a85976",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 334
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/de-DE/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/de-DE/translation.json",
+        "hashed_secret": "7c33cfa7df0e14e10c1858cd4849722c448bbc3f",
+        "is_verified": false,
+        "line_number": 381
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/de-DE/translation.json",
         "hashed_secret": "cc5213bdfc29aa15f1e530b9676b724be010f434",
         "is_verified": false,
-        "line_number": 330
+        "line_number": 615
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/de-DE/translation.json",
+        "hashed_secret": "0719708d1cc814839bd818fdc27d446652f03383",
+        "is_verified": false,
+        "line_number": 683
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/de-DE/translation.json",
+        "hashed_secret": "876ff6548acdb4f24bbc71f52e69fea3a26d28a3",
+        "is_verified": false,
+        "line_number": 973
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/de-DE/translation.json",
         "hashed_secret": "d581acf570521e6ca3d667a0516642a93d26dc6b",
         "is_verified": false,
-        "line_number": 540
+        "line_number": 978
       }
     ],
     "src/lib/i18n/locales/dg-DG/translation.json": [
@@ -314,49 +805,97 @@
         "filename": "src/lib/i18n/locales/dg-DG/translation.json",
         "hashed_secret": "49289db43e663a3df5e2c70714722ecc54895565",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/dg-DG/translation.json",
         "hashed_secret": "c2d404cb7bad34de0af2136b8efa809ea96170fa",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 186
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/dg-DG/translation.json",
         "hashed_secret": "4d5967896006c8a626ecef45e6312f6fc7d5b52f",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 225
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/dg-DG/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/dg-DG/translation.json",
         "hashed_secret": "f4708d832818f41ddc8e845e999b133bd1b50a93",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 381
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/dg-DG/translation.json",
         "hashed_secret": "2d99c4662bfa15c3037a03ef2b900f7f31d9059f",
         "is_verified": false,
-        "line_number": 330
+        "line_number": 615
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/dg-DG/translation.json",
         "hashed_secret": "9b0ca0e225ade9751c9a43289ab892be49e067fd",
         "is_verified": false,
-        "line_number": 367
+        "line_number": 683
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/dg-DG/translation.json",
         "hashed_secret": "a13be3d3c0a229c53f5167b726b504065cadf20a",
         "is_verified": false,
-        "line_number": 540
+        "line_number": 978
+      }
+    ],
+    "src/lib/i18n/locales/el-GR/translation.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/el-GR/translation.json",
+        "hashed_secret": "d8df6fe9cea0892b91d7f64179888900db9b76a2",
+        "is_verified": false,
+        "line_number": 76
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/el-GR/translation.json",
+        "hashed_secret": "58b60c3228c4ae1aaf8c0f62a2a97cdc97624844",
+        "is_verified": false,
+        "line_number": 334
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/el-GR/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      }
+    ],
+    "src/lib/i18n/locales/en-GB/translation.json": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/en-GB/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      }
+    ],
+    "src/lib/i18n/locales/en-US/translation.json": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/en-US/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       }
     ],
     "src/lib/i18n/locales/es-ES/translation.json": [
@@ -365,100 +904,230 @@
         "filename": "src/lib/i18n/locales/es-ES/translation.json",
         "hashed_secret": "4fc5ef3232218bf03f3b38b5c11704ba50901800",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/es-ES/translation.json",
         "hashed_secret": "669d5f2cfc1ed9dcb3d01957ee0ce90bf207306a",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 186
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/es-ES/translation.json",
         "hashed_secret": "51bdd24156132d44ca33a7760c30f2f4f8930ec6",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 225
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/es-ES/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/es-ES/translation.json",
         "hashed_secret": "eb9e8b4a699d6733b0f44ed3a85bbbfc397b09b7",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 381
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/es-ES/translation.json",
         "hashed_secret": "1663419d4c5ab66c4b655b30adc9c030f2cfaed6",
         "is_verified": false,
-        "line_number": 330
+        "line_number": 615
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/es-ES/translation.json",
         "hashed_secret": "5a6d1c612954979ea99ee33dbb2d231b00f6ac0a",
         "is_verified": false,
-        "line_number": 367
+        "line_number": 683
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/es-ES/translation.json",
         "hashed_secret": "86c39ce3c9657f07ef9f7fd28b3e949fcce72691",
         "is_verified": false,
-        "line_number": 541
+        "line_number": 978
+      }
+    ],
+    "src/lib/i18n/locales/eu-ES/translation.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/eu-ES/translation.json",
+        "hashed_secret": "89cd97a77a6485389abd55c7755657d662b5e3ca",
+        "is_verified": false,
+        "line_number": 76
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/eu-ES/translation.json",
+        "hashed_secret": "fd7c78de05d3c83b9dd029583940d37ad0a05a43",
+        "is_verified": false,
+        "line_number": 130
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/eu-ES/translation.json",
+        "hashed_secret": "33a470a5dc20c74bbbec4e2fa3a6c700ca7d76d7",
+        "is_verified": false,
+        "line_number": 186
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/eu-ES/translation.json",
+        "hashed_secret": "c35bdc847f4e9debe7087278ca5b9f569512984a",
+        "is_verified": false,
+        "line_number": 225
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/eu-ES/translation.json",
+        "hashed_secret": "861656e78797819f717b838996261cdbb0475f02",
+        "is_verified": false,
+        "line_number": 334
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/eu-ES/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/eu-ES/translation.json",
+        "hashed_secret": "b4063e26cc6530e332050a3b77578c51b9e5e1b5",
+        "is_verified": false,
+        "line_number": 381
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/eu-ES/translation.json",
+        "hashed_secret": "81e1aa06fdd7ba5419656bfbad38e8c142c2b054",
+        "is_verified": false,
+        "line_number": 615
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/eu-ES/translation.json",
+        "hashed_secret": "49dfd0828a78bf0139012f11f07b0d5e273362bc",
+        "is_verified": false,
+        "line_number": 683
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/eu-ES/translation.json",
+        "hashed_secret": "d302789162ce2130b054b59f9108b931bbeb75a0",
+        "is_verified": false,
+        "line_number": 973
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/eu-ES/translation.json",
+        "hashed_secret": "595feca3a569016b71c3b7969162e3123b13d638",
+        "is_verified": false,
+        "line_number": 978
+      }
+    ],
+    "src/lib/i18n/locales/fa-IR/translation.json": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/fa-IR/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       }
     ],
     "src/lib/i18n/locales/fi-FI/translation.json": [
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/fi-FI/translation.json",
+        "hashed_secret": "e6320da59edb21538c99c520cfe6cc506c97e25f",
+        "is_verified": false,
+        "line_number": 76
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/fi-FI/translation.json",
         "hashed_secret": "92651e851d1a520088933d6b71c6706fc9b7fffe",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/fi-FI/translation.json",
         "hashed_secret": "d37932fe41308c9dcfdbd1fcdcbb9327f5049e50",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 186
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/fi-FI/translation.json",
         "hashed_secret": "e2bd05b33960c216e57ed56d78343a18b85cf1af",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 225
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/fi-FI/translation.json",
-        "hashed_secret": "a8ee11c1a5753965b8313a70ab536645222f358b",
+        "hashed_secret": "0ffa589ab3ab813d19c0feba415b368ce7d0a195",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 334
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/fi-FI/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/fi-FI/translation.json",
+        "hashed_secret": "c7e6477ecef29604380f3185e205c3cc4ef565f3",
+        "is_verified": false,
+        "line_number": 354
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/fi-FI/translation.json",
+        "hashed_secret": "307b7a91dfc3680d5388b30d6c71e65576d5ec63",
+        "is_verified": false,
+        "line_number": 381
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/fi-FI/translation.json",
         "hashed_secret": "23ab1407e48805db207b5c230729bb0428209c73",
         "is_verified": false,
-        "line_number": 330
+        "line_number": 615
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/fi-FI/translation.json",
         "hashed_secret": "1edab3c25a852fdf601720cb0d533c3ca4374779",
         "is_verified": false,
-        "line_number": 367
+        "line_number": 683
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/fi-FI/translation.json",
+        "hashed_secret": "e03688fe117e50558953aec7dd6b6d748a8f872a",
+        "is_verified": false,
+        "line_number": 973
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/fi-FI/translation.json",
         "hashed_secret": "e5af6990909684754b5596537eef1a934d73c85d",
         "is_verified": false,
-        "line_number": 540
+        "line_number": 978
       }
     ],
     "src/lib/i18n/locales/fr-CA/translation.json": [
@@ -467,49 +1136,56 @@
         "filename": "src/lib/i18n/locales/fr-CA/translation.json",
         "hashed_secret": "4ad8d63169101cdbed62ae86f7bd8896fc591b22",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/fr-CA/translation.json",
         "hashed_secret": "88362d0d044cf4144e78f646e101110e3f44a9e5",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 186
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/fr-CA/translation.json",
         "hashed_secret": "f924297673a9a6a8f9362349954b1e5273549e28",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 225
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/fr-CA/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/fr-CA/translation.json",
         "hashed_secret": "9f4b33807e3f0e7a47fd5a90cf31214fee711c45",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 381
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/fr-CA/translation.json",
         "hashed_secret": "3a7138292007e17c98448b319ca6f2f6b63980f8",
         "is_verified": false,
-        "line_number": 330
+        "line_number": 615
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/fr-CA/translation.json",
         "hashed_secret": "94e2f3ee14b92e2e675a8f6118d28738dbf5c6ba",
         "is_verified": false,
-        "line_number": 367
+        "line_number": 683
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/fr-CA/translation.json",
         "hashed_secret": "bae8f42ef6afbb0a2e4669a4ff295888522670e9",
         "is_verified": false,
-        "line_number": 541
+        "line_number": 978
       }
     ],
     "src/lib/i18n/locales/fr-FR/translation.json": [
@@ -518,49 +1194,102 @@
         "filename": "src/lib/i18n/locales/fr-FR/translation.json",
         "hashed_secret": "4ad8d63169101cdbed62ae86f7bd8896fc591b22",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/fr-FR/translation.json",
         "hashed_secret": "88362d0d044cf4144e78f646e101110e3f44a9e5",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 186
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/fr-FR/translation.json",
+        "hashed_secret": "edc6c260332a06612b303abd591ff6946f044fc6",
+        "is_verified": false,
+        "line_number": 188
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/fr-FR/translation.json",
         "hashed_secret": "f924297673a9a6a8f9362349954b1e5273549e28",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 225
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/fr-FR/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/fr-FR/translation.json",
-        "hashed_secret": "e78e9f85f01ac0f7eaf0a8cb7c2c82852178778c",
+        "hashed_secret": "42cd7467407df728d1d720ddb791a1cec66ba9a0",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 376
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/fr-FR/translation.json",
+        "hashed_secret": "b143be2074005abae82f6c59716d659d9de76117",
+        "is_verified": false,
+        "line_number": 380
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/fr-FR/translation.json",
+        "hashed_secret": "9f4b33807e3f0e7a47fd5a90cf31214fee711c45",
+        "is_verified": false,
+        "line_number": 381
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/fr-FR/translation.json",
         "hashed_secret": "3a7138292007e17c98448b319ca6f2f6b63980f8",
         "is_verified": false,
-        "line_number": 330
+        "line_number": 615
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/fr-FR/translation.json",
         "hashed_secret": "94e2f3ee14b92e2e675a8f6118d28738dbf5c6ba",
         "is_verified": false,
-        "line_number": 367
+        "line_number": 683
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/fr-FR/translation.json",
-        "hashed_secret": "86cdaf4f337e43aa199425493916912ac1d5a0da",
+        "hashed_secret": "c93bde93cf91186126ade8bd198e4e966b446b4b",
         "is_verified": false,
-        "line_number": 541
+        "line_number": 973
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/fr-FR/translation.json",
+        "hashed_secret": "bae8f42ef6afbb0a2e4669a4ff295888522670e9",
+        "is_verified": false,
+        "line_number": 978
+      }
+    ],
+    "src/lib/i18n/locales/he-IL/translation.json": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/he-IL/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      }
+    ],
+    "src/lib/i18n/locales/hi-IN/translation.json": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/hi-IN/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       }
     ],
     "src/lib/i18n/locales/hr-HR/translation.json": [
@@ -569,49 +1298,251 @@
         "filename": "src/lib/i18n/locales/hr-HR/translation.json",
         "hashed_secret": "e2d213323944fbf2a0067bc09fcb34d93ec22fda",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/hr-HR/translation.json",
         "hashed_secret": "194c48e52d70a374349c5b325fc518439666fd6c",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 186
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/hr-HR/translation.json",
         "hashed_secret": "e365da9fb84960679ef0e6a8b8a990d3ba808b5e",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 225
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/hr-HR/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/hr-HR/translation.json",
         "hashed_secret": "9ec73158dcc1c601dd5e87a907b1cbd1e803bebf",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 381
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/hr-HR/translation.json",
         "hashed_secret": "87a1b650d7fb5575bb2c10e9a80c26836981348e",
         "is_verified": false,
-        "line_number": 330
+        "line_number": 615
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/hr-HR/translation.json",
         "hashed_secret": "f45bd814e195ef24309fbbd1cc4511b69a1451df",
         "is_verified": false,
-        "line_number": 367
+        "line_number": 683
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/hr-HR/translation.json",
         "hashed_secret": "6cb64e0a8aff5f2585246653c4584cc2e02cf35d",
         "is_verified": false,
-        "line_number": 541
+        "line_number": 978
+      }
+    ],
+    "src/lib/i18n/locales/hu-HU/translation.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/hu-HU/translation.json",
+        "hashed_secret": "18bcdf12f5ad0ce8b5c6e1d9b2642d2504472605",
+        "is_verified": false,
+        "line_number": 130
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/hu-HU/translation.json",
+        "hashed_secret": "bf3d576e48fcea75686f0f4c27c95838dfbb1b32",
+        "is_verified": false,
+        "line_number": 186
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/hu-HU/translation.json",
+        "hashed_secret": "7c16d30bd7d681b986a5391a5ce292f7b8caca60",
+        "is_verified": false,
+        "line_number": 225
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/hu-HU/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/hu-HU/translation.json",
+        "hashed_secret": "5fe353d4c6aa200d95cd949546984dd072660e1e",
+        "is_verified": false,
+        "line_number": 381
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/hu-HU/translation.json",
+        "hashed_secret": "7ced80bec08bf81ef5cb363f175ce17720bfee33",
+        "is_verified": false,
+        "line_number": 615
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/hu-HU/translation.json",
+        "hashed_secret": "5737d7a5fce8d937c7a963fd0385e320d326ebd5",
+        "is_verified": false,
+        "line_number": 683
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/hu-HU/translation.json",
+        "hashed_secret": "6960310a065886d2252d17662cd8d3ed12379824",
+        "is_verified": false,
+        "line_number": 978
+      }
+    ],
+    "src/lib/i18n/locales/id-ID/translation.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/id-ID/translation.json",
+        "hashed_secret": "d43b81387c114e5f11742d0a9639f69310e75aeb",
+        "is_verified": false,
+        "line_number": 130
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/id-ID/translation.json",
+        "hashed_secret": "42fdb4ab131f0292b845ab0e60881484f1fb9368",
+        "is_verified": false,
+        "line_number": 186
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/id-ID/translation.json",
+        "hashed_secret": "696ebc0f23224c87514aed4707130967985b59b9",
+        "is_verified": false,
+        "line_number": 225
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/id-ID/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/id-ID/translation.json",
+        "hashed_secret": "ba06abe8f7dad498c39390b512979253839bfcd1",
+        "is_verified": false,
+        "line_number": 381
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/id-ID/translation.json",
+        "hashed_secret": "7d0ab1b98a4c514e09870f3952e6cd2aab2646b7",
+        "is_verified": false,
+        "line_number": 615
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/id-ID/translation.json",
+        "hashed_secret": "cd868133dcb0731a817d35ac8288b26cbfe7f710",
+        "is_verified": false,
+        "line_number": 683
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/id-ID/translation.json",
+        "hashed_secret": "e21358f5a76f9e6d6982e38731f65715b2b5e0d8",
+        "is_verified": false,
+        "line_number": 978
+      }
+    ],
+    "src/lib/i18n/locales/ie-GA/translation.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ie-GA/translation.json",
+        "hashed_secret": "c976610b1d4d5521cfd3856c036b3442287efbef",
+        "is_verified": false,
+        "line_number": 76
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ie-GA/translation.json",
+        "hashed_secret": "c83913ac529ce1678c0466f72d9cc8a459889bf4",
+        "is_verified": false,
+        "line_number": 130
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ie-GA/translation.json",
+        "hashed_secret": "e4ef1fd013820e4a791a03b7a2a46b6a44d792ca",
+        "is_verified": false,
+        "line_number": 186
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ie-GA/translation.json",
+        "hashed_secret": "6eeb47a37ec89970cb108699655db18d8be47b8f",
+        "is_verified": false,
+        "line_number": 225
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ie-GA/translation.json",
+        "hashed_secret": "2b89090cb854a878696d3fdc7fbca4fed1b4c299",
+        "is_verified": false,
+        "line_number": 334
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/ie-GA/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ie-GA/translation.json",
+        "hashed_secret": "5874ecf505c350493c1bb7b1dbca79f729597df3",
+        "is_verified": false,
+        "line_number": 381
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ie-GA/translation.json",
+        "hashed_secret": "2b698ab83c4625472626758e395a9063700a2509",
+        "is_verified": false,
+        "line_number": 615
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ie-GA/translation.json",
+        "hashed_secret": "b9452f9a2089158839abccb5326ca33ae220dc7c",
+        "is_verified": false,
+        "line_number": 683
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ie-GA/translation.json",
+        "hashed_secret": "a256739b5f177387d4f78f72fd3f1c9189521ff2",
+        "is_verified": false,
+        "line_number": 973
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ie-GA/translation.json",
+        "hashed_secret": "ec4cee5b259435cd83d4c143eb284bb3bc37ef08",
+        "is_verified": false,
+        "line_number": 978
       }
     ],
     "src/lib/i18n/locales/it-IT/translation.json": [
@@ -620,49 +1551,83 @@
         "filename": "src/lib/i18n/locales/it-IT/translation.json",
         "hashed_secret": "25dadb7138d86f4c3797174d3c124b3357d064d5",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/it-IT/translation.json",
         "hashed_secret": "a5c98294893b562a4e06e677107a46c83e7589b6",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 186
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/it-IT/translation.json",
         "hashed_secret": "ece21a8f37cc46b1a336fca77a80ed6200eb1acb",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 225
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/it-IT/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/it-IT/translation.json",
         "hashed_secret": "c934463694c02aa07a75b545dd030e19e948ab9a",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 381
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/it-IT/translation.json",
         "hashed_secret": "5f853a79c8827da72059fc29fce706391d81afe9",
         "is_verified": false,
-        "line_number": 330
+        "line_number": 615
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/it-IT/translation.json",
         "hashed_secret": "8be3c943b1609fffbfc51aad666d0a04adf83c9d",
         "is_verified": false,
-        "line_number": 367
+        "line_number": 683
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/it-IT/translation.json",
         "hashed_secret": "e91b54bf46f693b0ca8050e9b7075d9046a65333",
         "is_verified": false,
-        "line_number": 541
+        "line_number": 978
+      }
+    ],
+    "src/lib/i18n/locales/ja-JP/translation.json": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/ja-JP/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      }
+    ],
+    "src/lib/i18n/locales/ka-GE/translation.json": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/ka-GE/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      }
+    ],
+    "src/lib/i18n/locales/ko-KR/translation.json": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/ko-KR/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       }
     ],
     "src/lib/i18n/locales/lt-LT/translation.json": [
@@ -671,151 +1636,281 @@
         "filename": "src/lib/i18n/locales/lt-LT/translation.json",
         "hashed_secret": "ead7dc3e9f10f4aa80f064b560d98a1bda320943",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/lt-LT/translation.json",
         "hashed_secret": "513a905817f321902a9b2a3d5be5c067c9f85fab",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 186
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/lt-LT/translation.json",
         "hashed_secret": "413e90497c6e0425e84aa3f77e8e3ab17c5d28f5",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 225
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/lt-LT/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/lt-LT/translation.json",
         "hashed_secret": "0b7481390586c070ea2078367e92ecc9acf06f00",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 381
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/lt-LT/translation.json",
         "hashed_secret": "d9059bb1ce58832ba2af410f4dbe4ed2c728d7e9",
         "is_verified": false,
-        "line_number": 330
+        "line_number": 615
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/lt-LT/translation.json",
         "hashed_secret": "f8b0e1b941a91a57087dc263d246cc134f02cdb0",
         "is_verified": false,
-        "line_number": 367
+        "line_number": 683
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/lt-LT/translation.json",
         "hashed_secret": "bf888edcf1b4e0eaf59a32d4ee1be402b7e44e65",
         "is_verified": false,
-        "line_number": 542
+        "line_number": 978
+      }
+    ],
+    "src/lib/i18n/locales/ms-MY/translation.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ms-MY/translation.json",
+        "hashed_secret": "79921d5249fe5e34221d50264e83f557021bc9ce",
+        "is_verified": false,
+        "line_number": 130
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ms-MY/translation.json",
+        "hashed_secret": "5243c1578655e6581a5909bf6dd95b66fb31dad5",
+        "is_verified": false,
+        "line_number": 186
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ms-MY/translation.json",
+        "hashed_secret": "16f381e5eb2f21dbe7fe2bb64955b540078d8bc7",
+        "is_verified": false,
+        "line_number": 225
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/ms-MY/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ms-MY/translation.json",
+        "hashed_secret": "7c7da9c1fc35bf22e2a35462a9b4cc5c17331df4",
+        "is_verified": false,
+        "line_number": 381
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ms-MY/translation.json",
+        "hashed_secret": "366ab6d7c4b56101ddf719a42fe695b5d0c467c7",
+        "is_verified": false,
+        "line_number": 615
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ms-MY/translation.json",
+        "hashed_secret": "1a7bac3c35b84b7d64c77561104888a9dbbb9d80",
+        "is_verified": false,
+        "line_number": 683
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ms-MY/translation.json",
+        "hashed_secret": "1d73e4e5082b23c64df5c23b11714bdacb25841d",
+        "is_verified": false,
+        "line_number": 978
       }
     ],
     "src/lib/i18n/locales/nb-NO/translation.json": [
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/nb-NO/translation.json",
-        "hashed_secret": "5d2c53ac8d209e42563cc4f33c9b90eeb02a26c3",
+        "hashed_secret": "a05bdc7c444ef64fe2008a2796133098d20d6a4e",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 76
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/nb-NO/translation.json",
-        "hashed_secret": "a6d1654d81f14e2cfbc16fcadaa6754641477982",
+        "hashed_secret": "5d2c53ac8d209e42563cc4f33c9b90eeb02a26c3",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 130
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/nb-NO/translation.json",
+        "hashed_secret": "d511dbaa6e1f2c4ec884a6ce8ba9f6297bf94832",
+        "is_verified": false,
+        "line_number": 186
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/nb-NO/translation.json",
         "hashed_secret": "f23a53dd9db2a3c65e960c65cc8db7efd1a4015c",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 225
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/nb-NO/translation.json",
-        "hashed_secret": "a4fba20546ce124c635d65f7146554147672b8a7",
+        "hashed_secret": "52e4cef6c6d73bd8c53c1ec6e3ee2edfea959af3",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 334
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/nb-NO/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/nb-NO/translation.json",
+        "hashed_secret": "59439a598a4eb480af29a1d6aedf3319ceb76b0f",
+        "is_verified": false,
+        "line_number": 381
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/nb-NO/translation.json",
         "hashed_secret": "56006cd615145c8627e3b342780b152336240893",
         "is_verified": false,
-        "line_number": 330
+        "line_number": 615
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/nb-NO/translation.json",
         "hashed_secret": "0bcfb4cb7d7779094d3ae6d319be4f9ec248cf96",
         "is_verified": false,
-        "line_number": 367
+        "line_number": 683
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/nb-NO/translation.json",
+        "hashed_secret": "effb4806930e8752ab08ac0421b79f8e423676aa",
+        "is_verified": false,
+        "line_number": 973
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/nb-NO/translation.json",
         "hashed_secret": "899cfdfef96d548732853f5626056f0909b4d519",
         "is_verified": false,
-        "line_number": 540
+        "line_number": 978
       }
     ],
     "src/lib/i18n/locales/nl-NL/translation.json": [
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/nl-NL/translation.json",
+        "hashed_secret": "65e757321c701a41ec4d09edd8059990cf1ebde3",
+        "is_verified": false,
+        "line_number": 76
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/nl-NL/translation.json",
         "hashed_secret": "d585a10e917c7bf9ac1be23a9878a961ec9c1f33",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/nl-NL/translation.json",
-        "hashed_secret": "2c9ea6a96dec0bc65ba9ac909a3fc7bd812e3e45",
+        "hashed_secret": "edf3c46e95e555dd17fb30f20fdc80cc731efcee",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 186
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/nl-NL/translation.json",
-        "hashed_secret": "742ec1081ff21dbbdf145fb67ed884878dcfbe80",
+        "hashed_secret": "b08bdd4b78894d535c744ef315b6d77012ced30a",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 225
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/nl-NL/translation.json",
+        "hashed_secret": "d90cf1221fb9f37dd46fbf0936c35c056b768480",
+        "is_verified": false,
+        "line_number": 334
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/nl-NL/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/nl-NL/translation.json",
         "hashed_secret": "b9b1c7096445bae795e2e96567448e527cc6c427",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 381
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/nl-NL/translation.json",
         "hashed_secret": "725ea37296a54e6c29821550146e3165545b820a",
         "is_verified": false,
-        "line_number": 330
+        "line_number": 615
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/nl-NL/translation.json",
         "hashed_secret": "8278b30ef12fdf2ca2aaa363ea2f2504f0543357",
         "is_verified": false,
-        "line_number": 367
+        "line_number": 683
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/nl-NL/translation.json",
+        "hashed_secret": "3a8c854728ad42f4b6acf49b26d5163bfb5605ff",
+        "is_verified": false,
+        "line_number": 973
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/nl-NL/translation.json",
         "hashed_secret": "60daa29ac7f2db6a4c4050d5beef0bcd0f5cec85",
         "is_verified": false,
-        "line_number": 540
+        "line_number": 978
+      }
+    ],
+    "src/lib/i18n/locales/pa-IN/translation.json": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/pa-IN/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       }
     ],
     "src/lib/i18n/locales/pl-PL/translation.json": [
@@ -824,100 +1919,135 @@
         "filename": "src/lib/i18n/locales/pl-PL/translation.json",
         "hashed_secret": "f1a109b757cd5f9316fa63059ebf23db9641e2e4",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/pl-PL/translation.json",
         "hashed_secret": "198364dbe2b1d4f5945696323cf5a6b8fc84ca98",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 186
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/pl-PL/translation.json",
         "hashed_secret": "bec2674463af79a024f2a1225bc0754d64431dd1",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 225
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/pl-PL/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/pl-PL/translation.json",
         "hashed_secret": "84f847d7ae3c0a8e86c8367c80360164308ece4d",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 381
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/pl-PL/translation.json",
         "hashed_secret": "3744df92b2f0b7d5354caf8d431dea1af5d41fca",
         "is_verified": false,
-        "line_number": 330
+        "line_number": 615
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/pl-PL/translation.json",
         "hashed_secret": "f6240c78d748397cfa3a1bf65767e2e127ba877c",
         "is_verified": false,
-        "line_number": 367
+        "line_number": 683
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/pl-PL/translation.json",
         "hashed_secret": "f53baf16521b8a82f077c61bc7b3a7045c0ffa7c",
         "is_verified": false,
-        "line_number": 542
+        "line_number": 978
       }
     ],
     "src/lib/i18n/locales/pt-BR/translation.json": [
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/pt-BR/translation.json",
-        "hashed_secret": "4307ac6814914760afcab08c898ee6b76c6058b2",
+        "hashed_secret": "5b366732434992133478b097646209415baa384f",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 76
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/pt-BR/translation.json",
+        "hashed_secret": "909dc509db399d67246906ee07e1adffa24a022d",
+        "is_verified": false,
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/pt-BR/translation.json",
         "hashed_secret": "256a78166d30210af682fdeab3588f1ffcad3cdd",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 186
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/pt-BR/translation.json",
         "hashed_secret": "d47ad93f8df2a3b04d7e35cd023ed0e66ef86d17",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 225
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/pt-BR/translation.json",
-        "hashed_secret": "e243b03927e549622017861ff9672fc4dd3764f5",
+        "hashed_secret": "7e6b898111f8cdc7bf79155745a5ab900d904dd9",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 334
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/pt-BR/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/pt-BR/translation.json",
+        "hashed_secret": "e311f139e7134401cff8e0a52e232539d1f897f3",
+        "is_verified": false,
+        "line_number": 381
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/pt-BR/translation.json",
         "hashed_secret": "5bfe18ca5d4c81584399c794cf8ce4420b453173",
         "is_verified": false,
-        "line_number": 330
+        "line_number": 615
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/pt-BR/translation.json",
         "hashed_secret": "deba0172511d5701d964202f4e5de698d5e07c67",
         "is_verified": false,
-        "line_number": 367
+        "line_number": 683
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/pt-BR/translation.json",
+        "hashed_secret": "62c37d9e84dbe7eb14c1c9a8a3857062aca0124b",
+        "is_verified": false,
+        "line_number": 973
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/pt-BR/translation.json",
         "hashed_secret": "a70dbf1ea1af652e4fd8ed9e96b1157ed0f29e8b",
         "is_verified": false,
-        "line_number": 541
+        "line_number": 978
       }
     ],
     "src/lib/i18n/locales/pt-PT/translation.json": [
@@ -926,49 +2056,197 @@
         "filename": "src/lib/i18n/locales/pt-PT/translation.json",
         "hashed_secret": "4307ac6814914760afcab08c898ee6b76c6058b2",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/pt-PT/translation.json",
         "hashed_secret": "256a78166d30210af682fdeab3588f1ffcad3cdd",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 186
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/pt-PT/translation.json",
         "hashed_secret": "d47ad93f8df2a3b04d7e35cd023ed0e66ef86d17",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 225
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/pt-PT/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/pt-PT/translation.json",
         "hashed_secret": "eb7ffef24e643ad5bdda5aac9dbcd1f02ab077ad",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 381
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/pt-PT/translation.json",
         "hashed_secret": "5bfe18ca5d4c81584399c794cf8ce4420b453173",
         "is_verified": false,
-        "line_number": 330
+        "line_number": 615
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/pt-PT/translation.json",
         "hashed_secret": "deba0172511d5701d964202f4e5de698d5e07c67",
         "is_verified": false,
-        "line_number": 367
+        "line_number": 683
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/pt-PT/translation.json",
         "hashed_secret": "a70dbf1ea1af652e4fd8ed9e96b1157ed0f29e8b",
         "is_verified": false,
-        "line_number": 541
+        "line_number": 978
+      }
+    ],
+    "src/lib/i18n/locales/ro-RO/translation.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ro-RO/translation.json",
+        "hashed_secret": "0756aa5e74e23b1ff838fec363b5be609716ee91",
+        "is_verified": false,
+        "line_number": 130
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ro-RO/translation.json",
+        "hashed_secret": "fa3b9e166344aa6e59356f83050ca5f5283ab8c8",
+        "is_verified": false,
+        "line_number": 186
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ro-RO/translation.json",
+        "hashed_secret": "c0d9421e5f5b75eae1609a112d61c4ef23a317f1",
+        "is_verified": false,
+        "line_number": 225
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/ro-RO/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ro-RO/translation.json",
+        "hashed_secret": "df062c0e0b7fc9594fa7e10e31ce2817c1249f07",
+        "is_verified": false,
+        "line_number": 381
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ro-RO/translation.json",
+        "hashed_secret": "ed74ba7f6af500a3512b7f153075ce913dc1aa0a",
+        "is_verified": false,
+        "line_number": 615
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ro-RO/translation.json",
+        "hashed_secret": "46e2d98f0aa3af5e847cdd3c93956121a8b2e6bd",
+        "is_verified": false,
+        "line_number": 683
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ro-RO/translation.json",
+        "hashed_secret": "267dc5897615d2a1cee8b3f82bfa81d46ab07ce5",
+        "is_verified": false,
+        "line_number": 978
+      }
+    ],
+    "src/lib/i18n/locales/ru-RU/translation.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/ru-RU/translation.json",
+        "hashed_secret": "5d2f490c9143ba5ca087f10ab41f841a67693a9e",
+        "is_verified": false,
+        "line_number": 76
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/ru-RU/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      }
+    ],
+    "src/lib/i18n/locales/sk-SK/translation.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/sk-SK/translation.json",
+        "hashed_secret": "b6e39d073e1fd53850318e060f33fbb6c21cea2e",
+        "is_verified": false,
+        "line_number": 130
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/sk-SK/translation.json",
+        "hashed_secret": "7805a9b5f255eb056782e66d4dc70b56bdb2520c",
+        "is_verified": false,
+        "line_number": 186
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/sk-SK/translation.json",
+        "hashed_secret": "302f2b5976cb65e9c739c502808573626fefd3e1",
+        "is_verified": false,
+        "line_number": 225
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/sk-SK/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/sk-SK/translation.json",
+        "hashed_secret": "e96457d27792e613a7e19ad99ca1ab98222557af",
+        "is_verified": false,
+        "line_number": 381
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/sk-SK/translation.json",
+        "hashed_secret": "487b683fd092e69674ad9518e6d454b5f5883f64",
+        "is_verified": false,
+        "line_number": 615
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/sk-SK/translation.json",
+        "hashed_secret": "894f36e5fe639267301de83d341819acc0a14d4b",
+        "is_verified": false,
+        "line_number": 683
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/sk-SK/translation.json",
+        "hashed_secret": "0c5903955e46cd9fd57c061feaa6b71324a03015",
+        "is_verified": false,
+        "line_number": 978
+      }
+    ],
+    "src/lib/i18n/locales/sr-RS/translation.json": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/sr-RS/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       }
     ],
     "src/lib/i18n/locales/sv-SE/translation.json": [
@@ -977,165 +2255,236 @@
         "filename": "src/lib/i18n/locales/sv-SE/translation.json",
         "hashed_secret": "f3d05b32264e405f6d8baa1967ebab2f7ef8e8b4",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/sv-SE/translation.json",
         "hashed_secret": "4c2af7d2c0d6f71be9f9c910133d9c959bcba08c",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 186
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/sv-SE/translation.json",
         "hashed_secret": "f4f799c3cb7f2238af56b48e3ba91829b11665ab",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 225
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/sv-SE/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/sv-SE/translation.json",
         "hashed_secret": "1716d41bf988306f05982b3fc00e3ca9579163ef",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 381
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/sv-SE/translation.json",
         "hashed_secret": "df0f79b49286619492e46dd47da974c3b8b41019",
         "is_verified": false,
-        "line_number": 330
+        "line_number": 615
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/sv-SE/translation.json",
         "hashed_secret": "445b8b3e668d3f4b9979f9ef33accb33b062edd6",
         "is_verified": false,
-        "line_number": 367
+        "line_number": 683
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/sv-SE/translation.json",
         "hashed_secret": "e3a052ee9985491f0e9bb058113badde374bca8b",
         "is_verified": false,
-        "line_number": 540
+        "line_number": 978
       }
     ],
-    "src/lib/i18n/locales/tk-TM/transaltion.json": [
+    "src/lib/i18n/locales/th-TH/translation.json": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/th-TH/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      }
+    ],
+    "src/lib/i18n/locales/tk-TM/translation.json": [
       {
         "type": "Secret Keyword",
-        "filename": "src/lib/i18n/locales/tk-TM/transaltion.json",
+        "filename": "src/lib/i18n/locales/tk-TM/translation.json",
         "hashed_secret": "efb4b8e444e747394c752b696a343333061b9982",
         "is_verified": false,
-        "line_number": 74
+        "line_number": 75
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/lib/i18n/locales/tk-TM/transaltion.json",
+        "filename": "src/lib/i18n/locales/tk-TM/translation.json",
         "hashed_secret": "303b4269104583e143b52caa3648db07b4517db6",
         "is_verified": false,
-        "line_number": 104
+        "line_number": 105
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/lib/i18n/locales/tk-TM/transaltion.json",
+        "filename": "src/lib/i18n/locales/tk-TM/translation.json",
         "hashed_secret": "e57089080bf152d8d6b439a1c9e76af5bce06db4",
         "is_verified": false,
-        "line_number": 124
+        "line_number": 126
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/lib/i18n/locales/tk-TM/transaltion.json",
+        "filename": "src/lib/i18n/locales/tk-TM/translation.json",
         "hashed_secret": "06458a201e000edeb35860cb07610157efe7b1c8",
         "is_verified": false,
-        "line_number": 366
+        "line_number": 372
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/lib/i18n/locales/tk-TM/transaltion.json",
+        "filename": "src/lib/i18n/locales/tk-TM/translation.json",
         "hashed_secret": "c90bd6a44e4c888fbe1205f7ebfdd973c59a787c",
         "is_verified": false,
-        "line_number": 409
+        "line_number": 415
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/lib/i18n/locales/tk-TM/transaltion.json",
+        "filename": "src/lib/i18n/locales/tk-TM/translation.json",
         "hashed_secret": "f4c8951e9e9eabfce68e037d1334c0028dbf2b06",
         "is_verified": false,
-        "line_number": 423
+        "line_number": 429
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/lib/i18n/locales/tk-TM/transaltion.json",
+        "filename": "src/lib/i18n/locales/tk-TM/translation.json",
         "hashed_secret": "5117d7ae58fcb3981a8ccfb68c30f20824e7653e",
         "is_verified": false,
-        "line_number": 465
+        "line_number": 471
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/lib/i18n/locales/tk-TM/transaltion.json",
+        "filename": "src/lib/i18n/locales/tk-TM/translation.json",
         "hashed_secret": "7b3d5b0efcaaeda6402bb21265491d13d349c58f",
         "is_verified": false,
-        "line_number": 699
+        "line_number": 708
       },
       {
         "type": "Secret Keyword",
-        "filename": "src/lib/i18n/locales/tk-TM/transaltion.json",
+        "filename": "src/lib/i18n/locales/tk-TM/translation.json",
         "hashed_secret": "d6108a97d4197064ad2463d427b22136065ee319",
         "is_verified": false,
-        "line_number": 700
+        "line_number": 709
+      }
+    ],
+    "src/lib/i18n/locales/tk-TW/translation.json": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/tk-TW/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       }
     ],
     "src/lib/i18n/locales/tr-TR/translation.json": [
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/tr-TR/translation.json",
+        "hashed_secret": "eb114fb505909d9c34e487f520ba55e289be0f6a",
+        "is_verified": false,
+        "line_number": 76
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/tr-TR/translation.json",
         "hashed_secret": "1e1e42345bda267fc34efa9b53123880a9da2e4d",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/tr-TR/translation.json",
         "hashed_secret": "3235ff92b36a0244d91f5f11e754382490b08530",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 186
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/tr-TR/translation.json",
         "hashed_secret": "0ddfe39a0dd903e4ab010774e00846e711035d0b",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 225
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/tr-TR/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/tr-TR/translation.json",
         "hashed_secret": "01f05ebe3488e85773e8ffe887535d92491f010f",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 381
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/tr-TR/translation.json",
         "hashed_secret": "5e0558dbdc670ea7b1c535517c9562029350728c",
         "is_verified": false,
-        "line_number": 330
+        "line_number": 615
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/tr-TR/translation.json",
         "hashed_secret": "eb2d1283068b1c5b684714357a4078791175df76",
         "is_verified": false,
-        "line_number": 367
+        "line_number": 683
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/tr-TR/translation.json",
         "hashed_secret": "5857841b0a59eb1a34759fe6c71a96f671e1de57",
         "is_verified": false,
-        "line_number": 540
+        "line_number": 978
+      }
+    ],
+    "src/lib/i18n/locales/uk-UA/translation.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/uk-UA/translation.json",
+        "hashed_secret": "1d0c491e7a1abbc6f44d211336e9593f531af250",
+        "is_verified": false,
+        "line_number": 76
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/uk-UA/translation.json",
+        "hashed_secret": "9bedcee371816cbf749668f45e25dade6fe401ce",
+        "is_verified": false,
+        "line_number": 334
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/uk-UA/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      }
+    ],
+    "src/lib/i18n/locales/ur-PK/translation.json": [
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/ur-PK/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       }
     ],
     "src/lib/i18n/locales/vi-VN/translation.json": [
@@ -1144,2239 +2493,2262 @@
         "filename": "src/lib/i18n/locales/vi-VN/translation.json",
         "hashed_secret": "9df34e7207b5e80e4e531ab272b954b5444d59cd",
         "is_verified": false,
-        "line_number": 82
+        "line_number": 130
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/vi-VN/translation.json",
         "hashed_secret": "c96b1d82d576f85e20b6af0d06a3676019d083e6",
         "is_verified": false,
-        "line_number": 114
+        "line_number": 186
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/vi-VN/translation.json",
         "hashed_secret": "9a3c6341b168320eca9cbcb3b10b4da42f461ea3",
         "is_verified": false,
-        "line_number": 133
+        "line_number": 225
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/vi-VN/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/vi-VN/translation.json",
         "hashed_secret": "0876bd0c306e52183e4d88844e8a31ab7a186de0",
         "is_verified": false,
-        "line_number": 216
+        "line_number": 381
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/vi-VN/translation.json",
         "hashed_secret": "4267a600ceea3e437e47d941631a87bd7918ee6b",
         "is_verified": false,
-        "line_number": 330
+        "line_number": 615
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/vi-VN/translation.json",
         "hashed_secret": "888c9c47cfe0a0fb3c58896221597615a31a6ed1",
         "is_verified": false,
-        "line_number": 367
+        "line_number": 683
       },
       {
         "type": "Secret Keyword",
         "filename": "src/lib/i18n/locales/vi-VN/translation.json",
         "hashed_secret": "790b8a6b072738e8d4896c7cd1d8da96b27247a4",
         "is_verified": false,
-        "line_number": 539
+        "line_number": 978
+      }
+    ],
+    "src/lib/i18n/locales/zh-CN/translation.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/zh-CN/translation.json",
+        "hashed_secret": "ca969b32cc0378f6ab51d33d0e10b0760ac40a96",
+        "is_verified": false,
+        "line_number": 76
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/zh-CN/translation.json",
+        "hashed_secret": "4bbbd43444910185aee6d1fbf8d224b0a49bdc8f",
+        "is_verified": false,
+        "line_number": 334
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/zh-CN/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
+      }
+    ],
+    "src/lib/i18n/locales/zh-TW/translation.json": [
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/zh-TW/translation.json",
+        "hashed_secret": "06832f1d78fbdf58739ee1805c787e80dc3f394d",
+        "is_verified": false,
+        "line_number": 76
+      },
+      {
+        "type": "Secret Keyword",
+        "filename": "src/lib/i18n/locales/zh-TW/translation.json",
+        "hashed_secret": "71e67e8e7f846ffebb47605fc45a726f6b0332f4",
+        "is_verified": false,
+        "line_number": 334
+      },
+      {
+        "type": "Basic Auth Credentials",
+        "filename": "src/lib/i18n/locales/zh-TW/translation.json",
+        "hashed_secret": "5baa61e4c9b93f3f0682250b6cf8331b7ee68fd8",
+        "is_verified": false,
+        "line_number": 354
       }
     ],
     "static/pyodide/pyodide-lock.json": [
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "007db6e79974bf844f32ea8096acc168d0789653",
+        "hashed_secret": "00a14e2743499a85d13a54c363ff8fb0fb493d03",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "0128a4c6689fcdbc05a775f258dcd0d4103d41f0",
+        "hashed_secret": "00dbf066898b47ecc144d45029bc781ab6b2c505",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "01d52d8176878d26f757834d71c1e34ed21b0809",
+        "hashed_secret": "017016428304059cee0d7e546575bec3137711f4",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "021d82b96563eb09e86ee5d3f2de0457b42a7074",
+        "hashed_secret": "02d107c89a92439064073368bf8a39b781a6817d",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "030c6702b9644cb6733ddfc1a14fe913cfddac64",
+        "hashed_secret": "04801827e233de5b3e4a780fecf969c6f5963f15",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "03e9dad5d107023ba2fdf2429f9adecb61d54568",
+        "hashed_secret": "04ca70cff31d156411eeb69a3115b125822b8ac6",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "04065965da3f831f60dfd08cf8c0fe1e25c1c2cf",
+        "hashed_secret": "060368aa5bcd1b89d6f38f434ce9250ecdb928cc",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "042b69efa29ba5aed3f3668da66852931e0d9711",
+        "hashed_secret": "0655f91c07e096f14d08c6f70fb11ac318fd1280",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "0551a592aa4ebdc476c837a3e985bd304cf5ab85",
+        "hashed_secret": "06e800b0780769978dde6333da0a579f85d77be0",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "063b6d00dcae1e5f7bdb9fe4442beb4bc23e332c",
+        "hashed_secret": "07ade32053d18cf8c17041d6914cd2f60c972ae0",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "0707699c61dee77db191aae9e625d2a4f53ca73f",
+        "hashed_secret": "07b847401ec9e63cce627fe22b10b33b4bb98cc0",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "0755f422803334f5e04caaba52437c80d6be4bb7",
+        "hashed_secret": "094c3e1bda19abb5f1b282ad24bdfefe9783c683",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "085d74f0f3bd2c57fe62f92f7e729b09de57bfae",
+        "hashed_secret": "0a18373303944f003e0f3fa0a36b64e1574ef0ab",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "094de74dc49e6873d0521ab4cf71c8a3eb735892",
+        "hashed_secret": "0aa39245f2de956852b8a8cac541ab3c2c563f1a",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "0b921e0f04e5a577bbdcdba63b2e9dc2c0301f06",
+        "hashed_secret": "0c33df673d929d271a99b29229e7dad62c6eab77",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "0b96589c763005d77c0a1e77e4a42c7c86fdc5bf",
+        "hashed_secret": "0cbeb177f14d0af73cc81112983deda244cf8425",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "0c1671f72d8f1d6187aff5e20c29680497d31d73",
+        "hashed_secret": "0d14dc8c4cfa327d446031b7ef7f602b409bbcca",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "0c19f2f131d2a2b9f252699557c323728e4e0dd1",
+        "hashed_secret": "0ef612d0b345a9917abb4a9698ac311143b6e0dd",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "0ea5c5bedbd22e7df5b384c2d7796e201bfbca9f",
+        "hashed_secret": "1035bf165b33d11e58d4707f06786936280e516e",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "0ed214abab3392debee3224aa146759476489d00",
+        "hashed_secret": "10378f33601ef0a84b25754678e197a0982cdf47",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "0f0eb4ab6ab3ec55c338fc7f901b72e6bb858a8b",
+        "hashed_secret": "113013f0875cc17c8c5eb14d5e4a457d6461eefa",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "10ab058be9c48c114b1207721de00c5a34a76dd6",
+        "hashed_secret": "11f070a0337af2de502ed2d3ff4e170749d9b673",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "1142e5d06e15d2bd54f48f54f838a776858c048a",
+        "hashed_secret": "11f18a288fc247b9261671f33c916f2c722d2114",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "12caa4803a5142f7fa7d28502f44db75c541c7af",
+        "hashed_secret": "1229ee175fe54023c51fce13b57044c28fd22bb4",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "12e17f3254c7fdf7413b208fd42a403e683696ad",
+        "hashed_secret": "123102fc9a7818e09ecff3b9d375c002ee277017",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "13286080c0a55b52e1152a94224b7b570f12015a",
+        "hashed_secret": "1482a310c8a81369ee2d890152521a4a6475e3cb",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "1369f8757e5d6ad510b7ea6afbb9a2e3fa5de5e6",
+        "hashed_secret": "168005ed3841717f7a29c6ab4d4d17ea618d4257",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "15b5d9f0df6addd1fa0a5941f5ed87d69fe8a368",
+        "hashed_secret": "187609c21361b6f03c84318ac67e7738896b6d82",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "16270e9258a598221b3ade21966beb026f3789c7",
+        "hashed_secret": "190e94cac4960bf2668455046d7760e2e0e28186",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "17b1d2616fd08969a5ae8a62fc594d79bb95308e",
+        "hashed_secret": "19979dc6d51012b4837c1f2568018f1e97a76291",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "17e848de2e97f34bab89b8f9164619f309439780",
+        "hashed_secret": "1b98908065cbbc8c5d4c3a697a5a2e2635979f85",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "192c3d0686d73cf2707db3cde849939ae8de307b",
+        "hashed_secret": "1c777ea45a221785202beee584f7aef6d5259f13",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "1a258c3339075ab14ab0235107a77c42e18d01ce",
+        "hashed_secret": "1ddb0c32e84c6fa569bcab3725c026f8a84c8517",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "1a575d2e15e9bfc7c7b97153e7fa3b3a3cbdad01",
+        "hashed_secret": "1dfc3374b98eac91fd3119715706973dddef131c",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "1ab03428bc6b70029920832d9674a357252749c5",
+        "hashed_secret": "1e14da8a51613774875c58f5aaaa19772922c26d",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "1c02ce0a8699754cc2ba860ea5c184ab3b195cff",
+        "hashed_secret": "1e4f1086fb46a88e89f2cf9c4df756f2dcad4b07",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "1c52b4e5c9190bb976e63fa9b1b7ac44b69e74a2",
+        "hashed_secret": "1edfc77f02669dad6e992fe16a99535f60ffa215",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "1ca51411e6ff89fdb837d1b9d25b8d40faa7165a",
+        "hashed_secret": "1fe6e11156bbd232fd93de4b6505a20d7fbdf978",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "1da2d29ea53475b4aa616a9dd53945da0cbaf594",
+        "hashed_secret": "20c0d3afd4042bbe6158556c0a4b9e5d770a8165",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "1db67a9bfbfdb7ddb2ad1cb936cb62364cbbf933",
+        "hashed_secret": "21d196265f7d22b1b589504c8099ce85050657e5",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "1ebb1f7af4b69287dbea7ea90f5131957b173039",
+        "hashed_secret": "22839485639d904f9a2b89af058d862220f31083",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "1eee1afe6abcf6f68e252924d36852b650f8ead8",
+        "hashed_secret": "22f50cbcaafbf6590b29e3f11501c131ebed1c9c",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "200b269fc9e1786025f673221103a2797f048475",
+        "hashed_secret": "25a4d6daaa54e0b77e32b7ec1367fc222f36c3be",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "2148df94c81b4c5109268707750eacfcb9e69086",
+        "hashed_secret": "283aaebad87f467f341fbcaa647c9345a73eff56",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "21e8bd3724654ab3fa1a882573e7cd338fd704c3",
+        "hashed_secret": "28d6fa6f788c0c2af2f75f7eb48b44b2f05314c1",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "23897578987c4061515b88baf9fa6c53be48c635",
+        "hashed_secret": "29e871f7ebbc957976f6b29a401b5c3d7da74cc7",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "254d541a0ba31a9957aa403dd0ab9931b25c3152",
+        "hashed_secret": "2a81808ad9ffba01bddd2b8234169b19feb02499",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "25b4300959e2406c121dd782ba0dbcb69780509b",
+        "hashed_secret": "2b031908c4db7841bcde61f064d353cbd934ea6e",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "261d5c297db7a56c998bf070133deb11ad6f478e",
+        "hashed_secret": "2b49db128752fa35cf3c04c6b55b7e55f5bb3848",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "265034d567d64ea72874994aafe0a4174471f2e0",
+        "hashed_secret": "2b5712a82a8feeaa6e841c53a3f466881170e5db",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "265bbd6dbd42bf8a7425bd3cf911a64b6165ff67",
+        "hashed_secret": "2b8c6eb67bbbd1e287dcde5f937eb2950dab1a10",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "26b7c61edac707785ade5618d6f00c7ca0c24afd",
+        "hashed_secret": "2bc44bb45a7ac88f3b2644fa52445341175f4117",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "26c6048122e509ec997e879ebb21c5223b3c2c8d",
+        "hashed_secret": "2d1ef2a406e8877306a986bda66ca6584ecf099c",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "26cf4a5513874f2f6f3d18ce8f49af8f21a1cf47",
+        "hashed_secret": "2d863f910f0c6654b0ce916703959329b5344019",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "270b76b6eb80c7aa1a430097d595d7b63940db16",
+        "hashed_secret": "2df8facba3de8d40bcec4b8668a2f9e364e4fdac",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "27d1c751228b6c72821e616cccf3e2723283f7a8",
+        "hashed_secret": "2fa535b874010aabad791788048ac3f6fa3b62e7",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "298a4aeb79c7203cb29f362494ff45e671a7aefa",
+        "hashed_secret": "2faaef85bf06577cb1bd26603035ec3a6031eb49",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "2995a1f8286b80bea3aa2bd0cc049b386d8a01fc",
+        "hashed_secret": "3112328758f637d74bf0febd5926710d140df811",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "2b2c72e21bef8aed2c1b42aa345a273e3e1a27b0",
+        "hashed_secret": "31a1c0792ab7026297fe88acf639f2233b0d5545",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "2d5033a5d2832cd49787d448b7e6b60f4bcb1fd3",
+        "hashed_secret": "31de3ef30d6c5d9b88930e77bd9c82031767072c",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "2d70820f06f97a309c1621490b1438630aec18ca",
+        "hashed_secret": "3205fb4794894e0e92d00f7280b477a0c0e0c954",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "2dd014d9a590ed9db86c9e8b46e05bbbc2ea03bb",
+        "hashed_secret": "32b1606f13176d22c592ff492f1fc1ce10b850d1",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "2e649f4b237d16cd4b2e928b1e503bcb2dbbea49",
+        "hashed_secret": "32de1e72af0c4c6274a41b6e4def96586f3ac8aa",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "2f2eabd71ea0ef5157c462c54627d20173f2b644",
+        "hashed_secret": "34332d9ec02abd917121467b9fc2a987a25b46f4",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "302baf63d82c358295387a3fe68940b9c06a80a5",
+        "hashed_secret": "3449a504cd1db7b68e286fa0ee9b60615b14d3fb",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "30d05b66d7bf907eebacf0127d8f5c245a74c398",
+        "hashed_secret": "3553b7e62528f07e5d86a66d7b87a1d83c18b711",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "30e2f59d32bc6950deeaadccae4e4266d8c5235f",
+        "hashed_secret": "35f8ec0c3b471a6da3313cd078d5268fcb318ec8",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "30ee54f11602d510b41c43e0113f521b69a5220c",
+        "hashed_secret": "37804d4ceac74a35c64ba85b415214e535e9ebb3",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "31fe88a014c1c017088bf9e605cff42e7af9b2b4",
+        "hashed_secret": "37d44d3f54d02dd47a9458d9f6fdfd77cbfae5e6",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "3239d865daf0b59938a97ecbcc91f57dbc2d1de7",
+        "hashed_secret": "386b4b5a89d6dd3959364d6be1278bccb6d8091e",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "3286f8d80085b9c9ed6a49a3b0e8bbebc1db048b",
+        "hashed_secret": "38e357e7bdbb479fc538df6600ac5b196cb37904",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "32ffc9fd03a73237aeea5cb0b60fb13aea9d2bcd",
+        "hashed_secret": "3910c64b082e3e7a931aa2e8040ac7f95917058b",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "351305d8811efa3cc5234fa24b9e0762a817b674",
+        "hashed_secret": "3cdf335667030696d59bcc2800f0c53b9207638c",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "352334f5e596e55f1fad62ade009c5d7f935171c",
+        "hashed_secret": "3ce600f2c8950cfe2fffc618cbbc246c3ae0ba87",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "35caaf45ce5f3158373667547fc37bc1a504ccc0",
+        "hashed_secret": "3d347707ef17690614d9643043c35718d322130d",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "361cd5793124a6747af1b0ddf4cc0be44050cd51",
+        "hashed_secret": "3d99a1e6a2b7089be43658bd5346be1c0e9035de",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "370aa59c765ae1f302a4f1766f684e702e8d0a94",
+        "hashed_secret": "3da61492c70fe33fa7310ed9b3135021fba26187",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "37242c49d59e01ff734a1c323aae7ca1198cdbe9",
+        "hashed_secret": "3e429f7a60e1d71abeeb2bf778198f5923ff4e37",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "3752ff66f6ae5fa5a036310c348e69dbc3509af0",
+        "hashed_secret": "40b3ccf99a10cbe8c7f9df20e2b5d1d0f8dd1d77",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "37cbbb9cacb9490ae2a204d72056f4aa41b98f8d",
+        "hashed_secret": "40d0b5d72d58f07a480f590f911001015c6ab267",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "387d680c59124bc82984f1586436b59538854f39",
+        "hashed_secret": "443df2a9bb523d41d19b815e8bfc97136a27cab7",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "3a34f2dde266937c55fb224c8dda0439e6e10739",
+        "hashed_secret": "454bb5c0e19977326bfa8a4ba75445dad914d3a7",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "3a8f83e1b3c329449c9893ff160ed0ee130b4a67",
+        "hashed_secret": "458bc3c9267e98e06e06bbd6c5c0fefe0decc8ac",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "3b3029373e0005ba1a3709faacc1e42487855747",
+        "hashed_secret": "46dcad8bb1f2737ac4759bd984bab03e8aef8de7",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "3d90410b04f86130e35b35438f5ee254af2fe90f",
+        "hashed_secret": "473dc9de521d8c05025ab5c8da102eec7ebf341f",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "3db5b15238dfb2b1a2f7dd4d22359e169f80edc2",
+        "hashed_secret": "476c00893b4bb37c4225d3be6ae5ecdbeafb652e",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "3dd570c2b3c2c4efa7fb26fbd46c3f844483db19",
+        "hashed_secret": "4775d46a24d917ed9db936b650016afec770de00",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "3e090016bdde84eab22a7c35d2154a42bb456a75",
+        "hashed_secret": "4820cfbc4e6078343bd870391eb64d97919ba45a",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "3f8ffa0ebf6be703ded98ea951890fbc321bebc1",
+        "hashed_secret": "48ad0a20ffc34a926131d559e9de9eda04acfd39",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "41f63cae923ee512fd8809c05718e16b6c75ba30",
+        "hashed_secret": "49d19a68e60ab5bb0d233b9fda16f1d4dbfa4cc9",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "423e76550167bd77934e0c75641f35594ab66394",
+        "hashed_secret": "4bf06c9aabb223407fc006f1e1f31748359b16b6",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "4418e2411c2458bbd26c907365cfecefb6c8d76a",
+        "hashed_secret": "4c0b9fb1e2ea83f1d13bdb03c08b801295033ea7",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "45701714fba5b1b9dd8626a768731a3c48aadd8c",
+        "hashed_secret": "4cea532fad242fa43918d8172b88f2aff3a5d72b",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "47e1c13c451ff7919fea3090b1f422ea035cf0c9",
+        "hashed_secret": "4f02dd4b6a2abd9f13985cd807dcd9ac5a923c79",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "494fdbf5adaddb33a9da94d0583273eac86d7080",
+        "hashed_secret": "4f1cfed8ba16cc20846bacc7c1c15f860e78ca97",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "4ae8924cd041549c277e5c54784116e993b009af",
+        "hashed_secret": "50f55f1dfbb147de10bf8d9759ed3a7dc94053a9",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "4c6add9b3477cacc03c68f3045b64e649e0ff36d",
+        "hashed_secret": "5164cc584963ec441ae4cedd5c5a811d98b5fc05",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "4cb604f16a6ab8f1978b9615a8f1f3e18c462d70",
+        "hashed_secret": "51fd32a5db3c6cc18a13f8b580fa0ebf842e2a9b",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "4e0664176238e6b0093600e9237f3614a8630940",
+        "hashed_secret": "52b40d9ac69f7d90e38e5c36ea3dba0fddc6dd7f",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "4f978af718722ce902939b0858e6a2abbebfa0ca",
+        "hashed_secret": "5396e15d5902ea20f5de1a5f142ed07fde15b580",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "50df3b92b6e0b86c007f9b307a35101173e02f84",
+        "hashed_secret": "53bb0da2c50b709efbac66c73e5ad342c6d52f93",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "514e7de9d7ca9c83c5a65cb8b49e09806e8c552c",
+        "hashed_secret": "54323521e003f888675358f36017aea2da8a8415",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "51e763f7569f6fa4d490ca030fad287f2eb6f788",
+        "hashed_secret": "54c49b540c18641654c2eae40a4d8b9e064c8336",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "5347f38dee5326593e81aa2f6eade3077868bac8",
+        "hashed_secret": "54f22030d831a580f6b0a615015e0502856f6ab5",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "53632aa56bc29617dbf5e12997645689fe4d4ce1",
+        "hashed_secret": "5632a1f30aa5bf9e934ffcda5a4c19cc74e49a69",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "54a06600d2c46dda14cdc7b5337234107e830e70",
+        "hashed_secret": "563bf43139c1b750cfe58bb27d55a3738a5e1aa5",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "54acfc7e326e4862a1fa5e119d0da42f26b386b3",
+        "hashed_secret": "569aa392fddfbcd1ad351d700d0d479bc4d6c971",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "55b8975e59dfad8bb0ddd156b9ab57e37dbeb5cb",
+        "hashed_secret": "56e3121b83769d723b50a66625a0e5d607483513",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "55c033ba72c4877b8b735bfa3352698a89cdfa76",
+        "hashed_secret": "580abfe0428b5a89b2bb76a04aa6ac7229f3a9af",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "56c4363f03f783640d9b67b8c5aa203ae0dc1686",
+        "hashed_secret": "584610be0d69e8a3f3cea65f634bb4f6bdcff723",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "5877d0d6fc34342d53d35c295f50173f135af079",
+        "hashed_secret": "585093ec04d1319aa17b0002a83003f885cad3f2",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "5948a1cec8f540404235cbdca09973968117822e",
+        "hashed_secret": "58e09c4c08d9ef6b5bf2eff08f0d86d1df8ea5a7",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "59d27b69bb413fbd36a9f3c391fe406b4ada6505",
+        "hashed_secret": "5a7222608e3817810afbed30ef9a618e2fa7ca63",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "59ef38201c5ea770c36bced5ca4bb00b83bb3baa",
+        "hashed_secret": "5a78494635e2e9ff06eb86b4669cbe2d99bc033d",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "5a6f9041cf563d4700fd358ef50258c77d28d26b",
+        "hashed_secret": "5a815b93278140cfc09b8559bf63a72eb4532a0e",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "5af25e06860d1a59cde345e0684c167695d17fda",
+        "hashed_secret": "5ab530ad30ba2c035be942f0dfa25a9bfcdc1433",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "5b1da116e7f4d00f457558752dfc6f04b25f8fe1",
+        "hashed_secret": "5af5ff1771de7d8896692b6925b31462658c1401",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "5b84ebbabf0963b1ebc528538ced130b81747a11",
+        "hashed_secret": "5b13f697082104a638a34c1515c8a3671a049e1e",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "5bf5790de8304e17c9ec220d6f75e0f3f30995bd",
+        "hashed_secret": "5cf4d37c284ffcdb641b88f4df90e828218d30ad",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "5ccad47b24ca879e152244e9bdadaa29058e3f31",
+        "hashed_secret": "5dd200e6e724efdab938c810e039ee71330f6fa2",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "5e91a43ff557732c92f560ca9f78d604c32cd96e",
+        "hashed_secret": "5f3bfed0085ca1b40cd2320d8df4421aab2a8e90",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "5f255176b907c8f46cd603e5d02940e4b1c5ce9c",
+        "hashed_secret": "60135f9b32a5cc0e277c5ce70fa753c7bec7465a",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "5fadbad85ab586509d2f0aee1169ad6b533ed869",
+        "hashed_secret": "60bed0f3b31495671b098bc0a18e36cde5e0f60f",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "60885830791e5828e2cc705c29247924bcc681cd",
+        "hashed_secret": "62a0b3d4bfe2615c3e5747b82d6fade519fec2e3",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "61653fc757362781c65f5f04355b59de9ea42832",
+        "hashed_secret": "63afbf52bb4513f50e15a942baa1081a60d60c63",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "62bceef78a8e7054f2dc1d32cfa0316f334f1018",
+        "hashed_secret": "64d7901bb4760c80b57b5dc6043bff7010b867ad",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "643e77eeacef41d1873d1662875ffc70664b2e97",
+        "hashed_secret": "663754f72bff37e00b07e8178f22e20f1f30df26",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "662f5cb21284618e5bc3d52dd3d842ca4af4471a",
+        "hashed_secret": "671c3f3fd73eb045f52bf6a6ecead5f14a1c182f",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "669a77ec7d80359d6c1ca135c3b0e4fc4f551e9e",
+        "hashed_secret": "676ec6dc08b1560c14c58180e95f6582615b8d82",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "698a33f49c4dc19d97886ac0049353d018e78043",
+        "hashed_secret": "678c77f228df3c4730fc1d9703cd6f7f777d8d6b",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "6de48698d9fe8006e688e8d358745e1dc880b72a",
+        "hashed_secret": "69d93befdea85b7adbf4d6a18ac05d0c9ac7f91f",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "6ee86d7219abcbfcaeffc6e71d0d860296dce8e5",
+        "hashed_secret": "69de855df2631a72e5578667e6db9803000056ca",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "6fd0d2671f4f5f825ab87f5190e2006b615db6d9",
+        "hashed_secret": "6b672e92f3724e6e328935276f4619426da2a936",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "709ed62ad1429d31ad3c0c715005e92789787320",
+        "hashed_secret": "6b78a0d6ad3fc9b1135adae080ab4774c7547f72",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "70a5f7bb9bd2cc720e7d4b6c8bea2e0e805cd5e8",
+        "hashed_secret": "6c405b1353d4d3053953ac8091d3db6e04a83971",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "7195626b23e9c971171a92b00b1511d1445ddab3",
+        "hashed_secret": "6ea8373abc610f3a3920654b00088e58d006e41b",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "7331db493518fdef3ff9f58096165d91503a8476",
+        "hashed_secret": "6f0f116aa775e89a7304b7658041ddc0ba00dedc",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "734d029062e63d4688cf7cf1d768966b9f6de534",
+        "hashed_secret": "6f4d4a6b8c912b5ff35c09cdb6b79e34607610e2",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "73ff58db0df4f90090fae8ae45e33b6a977cd169",
+        "hashed_secret": "6fbeddef954bef6107f8a05f9c4ac6a357795ade",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "746883e0c28102d29a31bbd9273574af938a999e",
+        "hashed_secret": "711a04a1414f0350457b0a6a923717ed834106f2",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "74c420b93a6b9427d20d741709c1c2f2d7858b82",
+        "hashed_secret": "72ecd4d6138c2d779722db1c403b306ba8ff86bb",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "74efa17aa1f0333441dd5a29a55b9a0a5d033972",
+        "hashed_secret": "73feb686f0700ff2e90e382b5e762355da1df596",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "74f3e90d6f80a3959ed6cfd7194ec5937fe8d6a2",
+        "hashed_secret": "782d39a7a4d56cf84ba6b43fbd6101114bc81d7a",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "755136c6506bbc3b41f17ae1d8eae9e4aa61e9ba",
+        "hashed_secret": "78f66e86df6ab8dc57c23c6ce747f708e64ad2f4",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "759e71c707ad2642901b50b1ed55480243ff7701",
+        "hashed_secret": "79696a853fff24140ce70b2daa802627c199f4c3",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "76337acce80b63aafa5c3c2c8b789e4ae3646b16",
+        "hashed_secret": "7a682f3777cf7ea2d2c3b2f38b39efd16c6713a3",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "76fbb3441579d44aa8421029793312f812d0ef85",
+        "hashed_secret": "7bdafa2bb711be77c28db2502e0589754ffed739",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "77286e2d855ff7c64c65c7dbd476c531d5a8f6e1",
+        "hashed_secret": "7e70c029f487dd9e7c9b849db36b97876fd93ce5",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "776259253cf27a262a1d7287c0f21eaf800502d1",
+        "hashed_secret": "7f4cdca195a78bb110702be58df4a51002bf69ce",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "785746499b3460e2729ec1eb70d467d8a0aaa177",
+        "hashed_secret": "80f6774238612d01aaf20ceb6dea3d6fe6a8316e",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "78751ea5db1e7f768697d83ffb385baa04aa656a",
+        "hashed_secret": "82b40784fca66ce1cc5bbca63f0764e48e90f796",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "7876bee7951850903f5cca287972040447defd6c",
+        "hashed_secret": "837ea8d7652027d507e5356e4057f20776e77156",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "790a06744fc5d6f30ad760e44d031e8f356d88a0",
+        "hashed_secret": "842490882070efb766d707354349673392f7f00a",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "79d35832789b78a2ffe5985afa9a90433a678925",
+        "hashed_secret": "8556326d33ffe413397738ad03488205ff18749c",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "7a569f630281bcb0111e9a987bf806626a7ed6cb",
+        "hashed_secret": "85615216f3dbdbc7e24c9cb07f6203b917faac9d",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "7af98faacc4fee79ea9d3f1f2063c63266b52133",
+        "hashed_secret": "8688ebab57a7476f1a2d7d483068e41d97623eb8",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "7b20a2acf6f3af7b54661fc5acd84271b748c662",
+        "hashed_secret": "86a6e9b1cc5eed538b497d2f1498257361ab2593",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "7d4e78e61cadec82aa5700efbb1e5a64dc71ee56",
+        "hashed_secret": "872efac630b15c8001b1354bf4c1bad4ad1d2872",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "7d96d2c3a1a4cb617936b4d381c582c7700b968c",
+        "hashed_secret": "87ee84ff360d1a3036f9ca732c82f3a7c5140090",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "7f14a4a61af714bb994cbe8e9dfbb0f718b10c26",
+        "hashed_secret": "8b8a6d713537803ed128e503c8683205e0f8da5b",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "80947b17e54eb7b0e98e5c853e56cb89fc9becd5",
+        "hashed_secret": "8ecfecfd03f0889f16e38552d6c17a5107f1f1fd",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "82a42cffab6dfb24962ec166fcf9e7c99f2abdc4",
+        "hashed_secret": "90d5bd18a35f1a86ce0c6f481a92fa141e90c0b9",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "84656fd8a37dc88ac804791811a1d431bc864cd5",
+        "hashed_secret": "912aace3cae86e2e4f50c9efe2c3982246b19c34",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "8481a9ba4e047bb01a2ab0dfa23f6156959f651f",
+        "hashed_secret": "9175156ccd61a213ada8e927e6fa98138d6121ef",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "86bd9788988888c568f26d657ed09c5168200381",
+        "hashed_secret": "92135b71027b28546b669302bbe537fb179553ef",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "87a28aa89d2fb7cf426013512e1ab0e1aeaac2e0",
+        "hashed_secret": "922dc040c6f096889414eb0ed30af83bd330d415",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "87b97a6bb31e0bb47bfa8cd5d32d2fb814a0ccef",
+        "hashed_secret": "9258b2e4dd3ed0b22d0b8bc882d65e03889d1fad",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "87e5f11252dcc0a630f9cf2d40aa3b0d94fc5288",
+        "hashed_secret": "93b009ea9e5d35e9a4809ef6be449e0be480c13d",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "88e50f701b3269ae26d820d6d1f18a6703e5ae3e",
+        "hashed_secret": "9762249d0fbec88a241e91b76172e5d3cf3d4e5a",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "8a3a274f3813c45dbe07e2a115513846a2ea4c6d",
+        "hashed_secret": "97a5417f67a5d1cbb1bb9b561cf129b0c94d8777",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "8aaddee6ac3414eed0a115fcb318780c4a4fb606",
+        "hashed_secret": "9859718aba0364ef91b3ea57de5fdd1db64354ad",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "8aca24adbd28dfb46262832d2175c684021d9d5c",
+        "hashed_secret": "987fb82b7b8b521a4ac5281c17f990fd63737736",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "8c56edc77cfcbc477554d9bc4c6ad743bd03d550",
+        "hashed_secret": "991a8f94ac507e723a1991dbbf3fbba8552f8f60",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "8c85b869bd224a625044c90c1425ca6709b1a69a",
+        "hashed_secret": "9939fac024199739a9b1e4ebaecd4442c34e7066",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "8c98cbd20c4e73b89fe6d696477a891ac5ad5ff7",
+        "hashed_secret": "9a039449fbce950420cb69f3fec7c8f62df662ed",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "8cce2a6d9896e871cb7573bc2d7447ee9a12cddb",
+        "hashed_secret": "9a9f645a79dcf919406ae6a89c86c74ede095c5c",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "8dbfc71e104272e5926d2d46240bfb588459f3f5",
+        "hashed_secret": "9c4f8bd71bda801d473d430c3cc47e2ffbbd30a6",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "8f4d941f5e70d4da8ea6832f7bc672f4db5df49e",
+        "hashed_secret": "9f0451ab32aa5756e777699755109c50c917742c",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "8f7ab25b014f1ffdcb942fc26f17dd95847d34c9",
+        "hashed_secret": "9f1e5563af0cfbe8497bea5d3c109da17102c87e",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "8fa3c00773a6b3cb9ea3dabff8a531ac52b7bb4a",
+        "hashed_secret": "9f51d7a21ec6e517d3d3f8673f9026b6af8685cd",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "9023ce23d9054c0dda192a06c40d91d56df77629",
+        "hashed_secret": "9fde61dfd357b5d15b74f63feb0c43f2a2a5c2ab",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "92758e10e99cf3f7d449033abadf33f5f8fba21a",
+        "hashed_secret": "9fea5d748b5022e5642baf05ad8e65dc0cfb5373",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "92ae7b2020135402b09d9ce334dfdf6e5a05926e",
+        "hashed_secret": "a0122bbd99f049925bcac184f33abaada028c93e",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "9336c46a3eb56abdc78a7c5d8d6ff0e300412cbf",
+        "hashed_secret": "a092e38684a717944609e6f8378cee9f85411d27",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "934c030f8f9a509cf650a20885701fd853a7667e",
+        "hashed_secret": "a0daec92bf92136e23ce8fad1659f9d923e4bbac",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "94ec2a24474ec11edfa01900c30e39ca65d7ed73",
+        "hashed_secret": "a135c0b5fc2271b4138e3525d91ee52c0c67c727",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "96d86ff7a689dcf27c7c92e866d141d966c0fb8b",
+        "hashed_secret": "a1444909955a16768547c6574b439e8997d58710",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "9733d9a586382fda19cf5c3b51e0edccda67b974",
+        "hashed_secret": "a25efe2bb17331b73366e03a2231651457544ce2",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "974a6970344c5deacbb279357bcf065a103c465a",
+        "hashed_secret": "a31790105c0f10be670f4bc9c366467b6387ccc8",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "975f69d642706b0931b9ea953f0c3cfa755f0e42",
+        "hashed_secret": "a4e899c5e95448a5e36b40ce964f39bf039f2c25",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "97ace0630a5a32f9d803ad4f029bb52b2c4f5262",
+        "hashed_secret": "a517c9967aa073a7c741e9f4faa320dc9508d373",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "9904c32990792e98b9fdab614bafef5e889736de",
+        "hashed_secret": "a518464f3883a2504021e36ea0e9721567527938",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "9a3637b26d42f2017227d1dff3bb07ca5a274093",
+        "hashed_secret": "a541fc29931a33571ca01dfe489b045a74818059",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "9ad7ac57115242c2af4db169ea62adc7e3aa3a6f",
+        "hashed_secret": "a542eb9136af107cab8b00b61bacc244655889ef",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "9c2f0fd8f4d18f4c89aa89ec3b5de31252e9b269",
+        "hashed_secret": "a63612fe419d326d189cedab0e9dcb7dd509a6dc",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "9f054310b94068a702a7135c194e4fe3f293981a",
+        "hashed_secret": "a6c1ef6955d0d984c338824b513193319947f59f",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "9f6df3a90d9fcc1d06e29612b95c7f3616958a92",
+        "hashed_secret": "a73502b639befc2956382e90951b1f13546175f9",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "a16a565c887ee0f777d512af47520f98ddb23ce6",
+        "hashed_secret": "a7c007007e9f4c840029c9a6daa1a6b45cf8385d",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "a1e1a2abbae9cbe9fec216b2017c7f278514767d",
+        "hashed_secret": "a89a10242d9c1839b549f3aed5b0e59f182fb220",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "a24fb87e8ef2b2c30e7e7e35c50e57c752849113",
+        "hashed_secret": "a8a3f2f18e67026e1856148c218f5beea99d10a3",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "a2719f8803e9168619b9c33fadc1add8d67f2fb4",
+        "hashed_secret": "a8baf9de932aaab12636e8f776360dcfbf618933",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "a2c6e581e572d9b13042cc88e4f0e961e68459d2",
+        "hashed_secret": "aa103e47aae310b40d944eee1c907c53b848b9f4",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "a32daccfc2ea689f9dfb44227f32ec00ebe8f9d8",
+        "hashed_secret": "aa64cb54e759bbc3e32b339dbfd9dc5a750f135a",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "a615297ba123cbc1c1c28df686cbf780fd4f43b5",
+        "hashed_secret": "aaec915700bfd0f64ec4f537e891f01bbe0e28f4",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "a62dda303a06f05c3b1087bfb73626551ab3b083",
+        "hashed_secret": "ab5a1249a73dcd230b499c6087b4327793019419",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "a6b06cabe42ec597a14f56c86966b5efa282d73e",
+        "hashed_secret": "ab77cbf49ac858538722e4db1cda7e118f4c6b5b",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "a6dbc155ac0a9d43627229f2bd6df550bea88b59",
+        "hashed_secret": "ad0e1bb7f4709e3b32b209747fe2f316086b7ff8",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "a6e6e7bff74f7c25815a082f866b5fddff7abdcc",
+        "hashed_secret": "ad2b671ac39705929e51bc79a052c382129e29ed",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "a7358ff74697dd0fd4f5edeced52ad8e842e637e",
+        "hashed_secret": "ae071f181c98dec640bb3505afead53069153cb5",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "a7ee797bdd65b4b4eb49d4f19eb0f3bf7ace529f",
+        "hashed_secret": "aec9322d95f609e997f99fa8057f1540285f031d",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "a8da24c9f37c06fdce7bd603083db01c227d945b",
+        "hashed_secret": "af429d627244e4b8d83136be99acdc839f1ee062",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "aa04b0554ff0f9fc541edf928f67eaf081ad7307",
+        "hashed_secret": "af62feb29d35eccc09ae5063823854123c419442",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "ace210f6ff2e8af8203d20b829a6d63db8b5962b",
+        "hashed_secret": "afe9a93315b18b8b6902d230ee57a8ca5462321e",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "ad821878a77f0eb6ea87c1571616779023ea9017",
+        "hashed_secret": "b005f3db4e0dae349d7aec297f99d58d46116632",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "ada67d44014c0f6b927e6073d9f01e6a3ec2dcbd",
+        "hashed_secret": "b00f7d6481423a91d060d4dacdd999bd8e5e2197",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "ae7fe665d6191f09dabd30970cc56392ec8ddd25",
+        "hashed_secret": "b0690228f48149768d6e743d89ba95ce35e30ce0",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "af4ed4143e4070b60242b935a5bb2691ae804caa",
+        "hashed_secret": "b0f6ed3cc7ea1f0983908331255847530197e970",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "af7c2cae3cfd459bc49b95a23c29008d88581c5e",
+        "hashed_secret": "b118f5a7fa65b543cde64195225e928f978c94c7",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "b1e4b33720db4376a5ea624e959c68146cc29c06",
+        "hashed_secret": "b286b72104246b089cffefe208d27155f97baf70",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "b1efb09571844800353a840009a89610a5d1ac48",
+        "hashed_secret": "b3f1455fb364836542022f7cb5893998603ee8e0",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "b20259b3bced98348818a91443fda5654088a689",
+        "hashed_secret": "b46b987926559bb0d94b901c1fa683f7cabe8b75",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "b36e40f861a7d268c59ceb36e528f99d3d0b86ef",
+        "hashed_secret": "b48e368b3f4ddbd9d907d0607eeb724a4ede5fd1",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "b4e272478a1692431f3df692b5a31a20b32fa03f",
+        "hashed_secret": "b52ef96d7e2af6a81c2497e78b0994dc31c5ab72",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "b5b923a3682d898cce2718dbb2341ec48f0a9bb1",
+        "hashed_secret": "b5945c2efcddd419cc02b00ac11cb2e095f3a51e",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "b6a6ceed8b43a6bbd9dfa5b001bf13a60e3f5306",
+        "hashed_secret": "b59f06a9433385886e98cef0d46f2286c31392dd",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "b7838c00cfb95e435f915e28beaa7257c055bd65",
+        "hashed_secret": "b5c8ee5d0e5417961d4a7125ff7b6aa31cec06d8",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "b7b8201a45c2ebcb0728deea56a3659d7ff40100",
+        "hashed_secret": "b73922c6dbf70c87bef41a3b34855072cb44d1b9",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "b92017102cf9801d44aa5ee793d6bb6a639efe6e",
+        "hashed_secret": "b9893d47dbfdb11b7a156436d1ebcdf56c38f58f",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "b9b07d9b585f9f6c5e5b75d81af0842b8cafeea1",
+        "hashed_secret": "bab7de69e9af5ab8ec1398410a2057a3ca93c05d",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "b9b7fa21b020a1ca2534d071efd535c22d8843ac",
+        "hashed_secret": "bca8d2ac9651ff84d49b8a50bf385ebf69ccd7d0",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "bb47af91e3e3a2ac9ff2d008a57d992a365948de",
+        "hashed_secret": "be4e7129dcb9743e64fffad2cc6c6a78d1b82cc8",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "bc576586d6db32323a132971d71b531c07d8ca4d",
+        "hashed_secret": "bfbdb361c4c5e439248c8eb5111992e3487091da",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "bc63c5c0ee3cc1d3aac0488a1b1ef1823d406648",
+        "hashed_secret": "c2ba85cdf5a8b4ced0787b864d512093e555d95c",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "bdd8fd0061a7b3ae446d4b90516043f48a2a7fac",
+        "hashed_secret": "c44cbe2d426139f571d939bac899f2afa5b961c9",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "be7713aa237a5c90f2115fcb2bdf1d0dfcab1180",
+        "hashed_secret": "c6da55789119db08ae9568ff26aafe7af95b05fd",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "be8996e2dd95e01ec6c2a307a81a9e6d633de5c8",
+        "hashed_secret": "c6dcbe180ea975f4d74dd4bd0d61ca1808cfcb16",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "bf768803abbf259d5a36d23936f05cd078713455",
+        "hashed_secret": "c7827c4b7c18786dc4e58e495094b821c7298d5b",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "c018de719fb3c80fef04f50da29b7ddf1b7f2309",
+        "hashed_secret": "c9ee228057eeb4d63878da40d97c3e0f95a5a3ff",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "c04b27bd18deca286717d6efd6f17ce5b8149318",
+        "hashed_secret": "caaceee0e1a72812e6ca063d688a948ad515eaf1",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "c0a074fbd8748e9b8b0e8e53ca4f8441126f9270",
+        "hashed_secret": "cae4488fa343856bff8f95d520d46fe68245ecbb",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "c1f960f45e4250bf9acb060302badc97c61b9ad6",
+        "hashed_secret": "cb7dc732eff345002d78ca9a0173befd6cc5567f",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "c237dbf82eec8e51127e9150638138f57d799772",
+        "hashed_secret": "cc5d9d46a202a5e1bdd5a134255c858237006f87",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "c3b84a331d12e1a6a2cd476b4cd62c118ff5061d",
+        "hashed_secret": "ccb08f20d83f1466e1af62bfd3a1ff8d7813bd80",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "c3fb0084bd34d9cf7c303d055a5da99486760ab0",
+        "hashed_secret": "cd289e3ac0723894ba64fb62d1e697b981c2dbcf",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "c59fbeb88d83e79c616561863c55657042ad47da",
+        "hashed_secret": "cd53ef721058a2f5415b064343ae71a3ec040e7c",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "c9ef6c389fe208257ee781185f69ee484d0c23d8",
+        "hashed_secret": "cd8860d8dddb3b0fb5eda48e98b41d7b0a668eb9",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "cbc5bd1f4cda877467f5d81b2a92e16f564e7811",
+        "hashed_secret": "cd8cd559d262600be9795bb0ea96c93970f18575",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "ccd5a63f2ed92f85f58a64eddf33d7fc53537115",
+        "hashed_secret": "ce3975831d5d2fee5ce684183e125884e14e4c95",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "cdb07db150ccb371e9f18e24e55c90d9793d420d",
+        "hashed_secret": "ce75d3ca13ad0447b321c8f98bb2d3a6388ecd05",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "cf405f2aabe10ccb6264d5b16c37ab2613aab604",
+        "hashed_secret": "ce7a2d76ebee5c2993594184eba34fd1aff27aba",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "d0753a4bbbbbd2ba2f15039b690aa2d39e24c91d",
+        "hashed_secret": "d0011014c6179e64b2e0b9af1066d324c46a73ba",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "d0f71460d0dcb1c77b59724c8405fc5ed51a9e96",
+        "hashed_secret": "d0bbca7f674acfb1cfb1861423f63f0c6f5f1bf9",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "d5ff9211fc43298aaedc401b4d06c1db42818d53",
+        "hashed_secret": "d115a90fc2f4ad808951c69d8dc6b7be9d7083e1",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "d6aa3864c6a844886c8d10a9c3572a272d9c7588",
+        "hashed_secret": "d4e9c963f0b5ccc183efa8b5ca873d51040a2548",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "d7f8b8c315df7a4bd290e2fd624c0e08bcac4f9e",
+        "hashed_secret": "d4eac6de7c22d941a8e3a8ee6ccbe0dd059d2019",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "d81ccd2e2eee698d2035d9eb232310ae6ef20c03",
+        "hashed_secret": "d6a4469459433e839c0138155d8715bb121ace2e",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "d8b24a5a0b970567b10b9eca2d3f1256d3d912e6",
+        "hashed_secret": "d946f9a786a6c1cc15357e79a1e1b78fc5ccecf5",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "d93e24f89b5e5f47e8c1422977a28db452ee6db2",
+        "hashed_secret": "db184c111c72cf8cf6a35e101f454db7e87f1e60",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "d9d139f1eafd1d32368790590169d1714f9d7b0a",
+        "hashed_secret": "db33d7d51b9c4d07c63f333d6e83b7ab5773660c",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "d9f1955a936ab4ab5488d61cd329d6d5fe3f60e1",
+        "hashed_secret": "db8ae78e83b0f3b4f578c3fc41bfcafffa887621",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "da852670c29ac0df9eb7ac8e9ca69028e53c0dc4",
+        "hashed_secret": "dc58fd1ffb80a71acb19ffae7b0fed12ed9f7718",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "daa6528daba791e3afa689fce6a805571aab249b",
+        "hashed_secret": "dc81f7a8aafa024d7d18bcb2e7222cc934f039d6",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "daef057ea344f8ad0c60d6c517c4b3877ab3e79e",
+        "hashed_secret": "de5987078a5e732e3a12d35f96f9fb56c369c231",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "db2e05488367af3c805b188163728c756dad71e9",
+        "hashed_secret": "ded4190e968a7d226a7b845cebfc5935aac17b5e",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "dcba8ae280c8ddccefa2e30854d009dd34360207",
+        "hashed_secret": "e08b0df6fc627abc1f601457c5f58a38a4a0b993",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "dd1c5cf97ecb2655193a2ee76b9201443445a0a0",
+        "hashed_secret": "e0fb7f9f229ab13d2f434938ebe8f9aa5748841c",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "dd35fee567d540fff45f6003070ae57da07c5cfc",
+        "hashed_secret": "e113f2e073e1db68250be4e6544b3148d91c5c90",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "dde5090e3b7d9580600b55d7b0a6fc5e70800f0e",
+        "hashed_secret": "e16b32d709dc9e3b7d19b818e61942eef954abc6",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "df347b2ea28dff8f6559c9d90ad83251399435a3",
+        "hashed_secret": "e2a5e100d9ddd1ac84795439c32f00bc043f8bb1",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "dfa47f9404950a08e8636b2d42822febcb03fcd8",
+        "hashed_secret": "e2fbbed6ff450b484db7ff9673bf2a267f5c8f9f",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "e054d57018fb038fe828d5aac60580072dc2e1ff",
+        "hashed_secret": "e31129a3acc841a47061c5f7f63cbc5ec58d05ee",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "e19c8d02329feaa356624f3e6403ed948bea7ecd",
+        "hashed_secret": "e316b053d9c4acb3aa267d4ec1f25fb4cf79c59d",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "e2064ae3dbd6791445d000f723f3e769e85af361",
+        "hashed_secret": "e318956f6ae96bcbeb4453a58b8d39ab2be0b749",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "e2925b25d910cd31e61cd32870d691fb4a385a80",
+        "hashed_secret": "e493f63d852f8135550a02203fb3bd766c00c5c3",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "e2df211f914246b7ddf3325c0df801dc394609b6",
+        "hashed_secret": "e497b99327a1de39fc6c9be6acf8292f6db88ac4",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "e4562da0fdc795923a10a69aa42d3460efa40902",
+        "hashed_secret": "e7a053d08c3ac080abb3659165e90e797a2a48b6",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "e487a2828044b22227139280da5eac8bc7be2442",
+        "hashed_secret": "e7e65731416d3066a0524e1f4872a7de95b73f88",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "e4c698725da4fcbca18418a72563cee44063d363",
+        "hashed_secret": "e84e599af3b61dc8e92f8012ae83df0123838545",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "e5a71f998efcd3fa03a4901a57d9cbb856e45253",
+        "hashed_secret": "e8a70103f8c13c62036a135d296bb3aae82e0a8c",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "e6f139bb3e9dd1f452fb3e4cc7cef3e7bbb58325",
+        "hashed_secret": "eb459554eaae280f1d8165b3576701dc3354e044",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "e88a4dbe3e0f6c466f2bb80a4c6284e87f97ae1d",
+        "hashed_secret": "ed774dc0e657734a9adb470083034e9f83378028",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "e8a709d5cfd94170840f0c5e3fdeb0d410896e61",
+        "hashed_secret": "edd6d40f3f9e2d94eb3ea918b4edca0ab50e3653",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "e8e03e3676950bbc7d5cc6f6a798204b51269c56",
+        "hashed_secret": "edf6f0e6fd8c9b9ebd279e93e8f47acc96bbaa29",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "e8e2b145de5c6d11a66f563e881b40f2d0386942",
+        "hashed_secret": "ee4848a5da8d06f485312a19942f172ca86b44f6",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "e9ddd38fdd53367fb1fd73389674d7fcbda77a7d",
+        "hashed_secret": "f040c333023f0673485c21c20347882f4a61c960",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "eb048a83f19540c1374e0d91aca7b78f6d096acb",
+        "hashed_secret": "f286cb871332c0787a355a9a07ff36cb4d86a779",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "ebdff8b0897405fb6177ac8a56bdda5587c812f8",
+        "hashed_secret": "f3116f16b0d9e3978867f129be67354e2e16d10a",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "ec0531429221482a5f8b8ed97e8399467caf37fb",
+        "hashed_secret": "f3183ab3c2d2464a6e6ca52c2fe8a053644dbfd9",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "efaa9672b44b8995fccd9cba6306349a18e50254",
+        "hashed_secret": "f3af65c43366a2347cf2883f980e10b42a225273",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "f17a6b091fc1948913ad3185beb1f7982e711c9a",
+        "hashed_secret": "f429d18ae11effa60ef0560c0910279c21ca6ddb",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "f194c6cc76b7222617a1fd4b4085974026e36c24",
+        "hashed_secret": "f64c2c36a61569bedefe3e6878ecbae86aa688f1",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "f2660c981e9947e76bee556e847ab26664826915",
+        "hashed_secret": "f67c9ae0140cce00479210718a048b3cc7e842f5",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "f27f6853fce0010c8a522be027164e953bda965a",
+        "hashed_secret": "f6a8d234f5e6ae33d2f9fe6261c6baeeade1ad2a",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "f346e4900bda8a6c5a7d8bee39d94c719d92a625",
+        "hashed_secret": "f74162cd119e1b5f83ed6e62737f80731714d9f0",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "f349af313326323645af39eb5d3f80d4b6f4a43a",
+        "hashed_secret": "f92fca90988b0d4852e3d0286e51fa70d38cbeca",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "f690a9f194c41ef32bd14fa3fbbab76e6043050c",
+        "hashed_secret": "f9769e6cfab9491618f1abefa263e74636e5bf32",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "f6a4afd3b84329c2ca2d11df3fc231af3316f1fc",
+        "hashed_secret": "f9a1ad12882f80b847e0dbf905918973677ea7bb",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "f6d4b991ad6f98d9f909f7062c5200f9d8c0c08c",
+        "hashed_secret": "f9a8ef74349e27d909a99ca3bcb85baf6788cd86",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "f70fb40cfc73e977a09a6a35239e20778ebe24e6",
+        "hashed_secret": "fa2d418b429d95a5488b1f7f5bcd99ff79d88453",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "f85eb42b166715194b50f310f489ace520a0ea48",
+        "hashed_secret": "fab3885fa71485b526105bd5be5dfd6887acb19f",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "f903340921427ce6f27d37f8eefb2710ccc2dbcb",
+        "hashed_secret": "fb1ab34752553571eadbe06e086dcd1c7d416860",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "f9910d0f640dd5047afdedd42e94a8a4eb1e659f",
+        "hashed_secret": "fb46005da7117b5062fa810727095cb095efc48c",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "f9f7d58e11700162b8a0961756db5c959acd8e47",
+        "hashed_secret": "fb93c6a72083dea1cef313d36e59e2f7340e9ade",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "fa8df89aa739f3547ad658ac2f3e75673dd625e8",
+        "hashed_secret": "fbca540b96304688cb503ff74eaf19845d8f9688",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "fad888fa9d7d00c30ad3ed01663402326170ece5",
+        "hashed_secret": "fd054ee8519b16f8a7589170ca91906319715ef5",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "fda2fe8d5e53ac6f6df729f7d25defc591f17ac1",
+        "hashed_secret": "fd45bca275b9767079433bcd1246f55bcf7f50b3",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "fdff18e69133d7a0ca798c1dec4662cd168b9a3a",
+        "hashed_secret": "fedd9a79614cd3cb204736a466991b95d79ec07c",
         "is_verified": false,
         "line_number": 1
       },
       {
         "type": "Hex High Entropy String",
         "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "ff2e961a438603ab2d5f0c3e418e6fb9acecc875",
+        "hashed_secret": "ff4a84e9ba30eee92505d833fa2cfcb2ef9eb0fb",
         "is_verified": false,
         "line_number": 1
-      },
-      {
-        "type": "Hex High Entropy String",
-        "filename": "static/pyodide/pyodide-lock.json",
-        "hashed_secret": "ffd1c5c6b8db2241544f2702ffa52139ae8fe4c6",
-        "is_verified": false,
-        "line_number": 1
-      }
-    ],
-    "workflow-archive/integration-test.yml": [
-      {
-        "type": "Secret Keyword",
-        "filename": "workflow-archive/integration-test.yml",
-        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
-        "is_verified": false,
-        "line_number": 77
-      },
-      {
-        "type": "Secret Keyword",
-        "filename": "workflow-archive/integration-test.yml",
-        "hashed_secret": "dff6d4ff5dc357cf451d1855ab9cbda562645c9f",
-        "is_verified": false,
-        "line_number": 123
-      },
-      {
-        "type": "Basic Auth Credentials",
-        "filename": "workflow-archive/integration-test.yml",
-        "hashed_secret": "afc848c316af1a89d49826c5ae9d00ed769415f3",
-        "is_verified": false,
-        "line_number": 152
       }
     ]
   },
-  "generated_at": "2024-11-15T04:49:12Z"
+  "generated_at": "2025-02-18T20:50:20Z"
 }

--- a/backend/cohere_proxy/utils/aws.py
+++ b/backend/cohere_proxy/utils/aws.py
@@ -24,9 +24,7 @@ def refreshable_session(
             DurationSeconds=900,  # 15 minutes
         )
         credentials = response["Credentials"]
-        print(
-            f"Assumed role {role_arn} with expiration {credentials['Expiration'].isoformat()}"
-        )
+
         return {
             "access_key": credentials["AccessKeyId"],
             "secret_key": credentials["SecretAccessKey"],

--- a/backend/open-webui-pipelines/utils/pipelines/aws.py
+++ b/backend/open-webui-pipelines/utils/pipelines/aws.py
@@ -24,9 +24,7 @@ def refreshable_session(
             DurationSeconds=900,  # 15 minutes
         )
         credentials = response["Credentials"]
-        print(
-            f"Assumed role {role_arn} with expiration {credentials['Expiration'].isoformat()}"
-        )
+
         return {
             "access_key": credentials["AccessKeyId"],
             "secret_key": credentials["SecretAccessKey"],

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -44,6 +44,8 @@ from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 from starlette.responses import Response, StreamingResponse
 
+from ddtrace import patch
+
 
 from open_webui.socket.main import (
     app as socket_app,
@@ -349,6 +351,7 @@ async def lifespan(app: FastAPI):
     yield
 
 
+patch(fastapi=True)
 app = FastAPI(
     docs_url="/docs" if ENV == "dev" else None,
     openapi_url="/openapi.json" if ENV == "dev" else None,

--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -74,6 +74,34 @@ def get_http_authorization_cred(auth_header: str):
         raise ValueError(ERROR_MESSAGES.INVALID_TOKEN)
 
 
+# import json
+
+
+# def log_request(request: Request):
+#     request_data = {
+#         "method": request.method,
+#         "url": str(request.url),
+#         "headers": dict(request.headers),
+#         "query_params": dict(request.query_params),
+#         "path_params": request.path_params,
+#         "cookies": request.cookies,
+#     }
+
+#     # Read the request body if it's a POST, PUT, or PATCH request
+#     if request.method in ["POST", "PUT", "PATCH"]:
+#         try:
+#             body = request.json()
+#             if len(body) > 1024 * 1024:  # Limit to 1MB
+#                 request_data["body"] = "Request body too large to log"
+#             else:
+#                 request_data["body"] = body
+#         except Exception as e:
+#             request_data["body"] = f"Error reading body: {str(e)}"
+
+#     formatted_request = json.dumps(request_data, indent=4)
+#     logging.error(f"Request: {formatted_request}")
+
+
 def get_current_user(
     request: Request,
     auth_token: HTTPAuthorizationCredentials = Depends(bearer_security),

--- a/backend/open_webui/utils/auth.py
+++ b/backend/open_webui/utils/auth.py
@@ -74,34 +74,6 @@ def get_http_authorization_cred(auth_header: str):
         raise ValueError(ERROR_MESSAGES.INVALID_TOKEN)
 
 
-# import json
-
-
-# def log_request(request: Request):
-#     request_data = {
-#         "method": request.method,
-#         "url": str(request.url),
-#         "headers": dict(request.headers),
-#         "query_params": dict(request.query_params),
-#         "path_params": request.path_params,
-#         "cookies": request.cookies,
-#     }
-
-#     # Read the request body if it's a POST, PUT, or PATCH request
-#     if request.method in ["POST", "PUT", "PATCH"]:
-#         try:
-#             body = request.json()
-#             if len(body) > 1024 * 1024:  # Limit to 1MB
-#                 request_data["body"] = "Request body too large to log"
-#             else:
-#                 request_data["body"] = body
-#         except Exception as e:
-#             request_data["body"] = f"Error reading body: {str(e)}"
-
-#     formatted_request = json.dumps(request_data, indent=4)
-#     logging.error(f"Request: {formatted_request}")
-
-
 def get_current_user(
     request: Request,
     auth_token: HTTPAuthorizationCredentials = Depends(bearer_security),

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -104,3 +104,5 @@ googleapis-common-protos==1.63.2
 
 ## LDAP
 ldap3==2.9.1
+
+ddtrace==2.21.0


### PR DESCRIPTION
Add fastapi hooks for dd according to simple setup here: https://ddtrace.readthedocs.io/en/stable/integrations.html#fastapi

We should already get most fastapi integration out of the box from the ddtrace agent that is running on the kube cluster, see here: https://ddtrace.readthedocs.io/en/stable/advanced_usage.html#ddtracerun

This patch() will allow us to override a few config options for what fastapi sends to datadog in a versionable manner.