### PR TITLE
remove 10x branding references

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -563,16 +563,6 @@ if gsai_logo.exists():
 else:
     logging.warning(f"Built by logo not found at {gsai_logo}")
 
-built_by_logo = FRONTEND_BUILD_DIR / "static" / "10x_ai.png"
-
-if built_by_logo.exists():
-    try:
-        shutil.copyfile(built_by_logo, STATIC_DIR / "10x_ai.png")
-    except Exception as e:
-        logging.error(f"An error occurred: {e}")
-else:
-    logging.warning(f"Built by logo not found at {built_by_logo}")
-
 ####################################
 # CUSTOM_NAME
 ####################################

--- a/src/lib/components/layout/Help.svelte
+++ b/src/lib/components/layout/Help.svelte
@@ -10,43 +10,31 @@
 	let showShortcuts = false;
 </script>
 
-<div
-	id="footer"
-	class="fixed bottom-1.5 right-0 px-2 pt-2 z-20 flex lg:flex-row flex-col items-end"
->
-	<div id="by-10x" class="lg:flex text-xs text-white-500">
-		<a href="https://10x.gsa.gov" target="_blank" class="flex items-center">
-			<span class="hidden lg:flex">Powered</span>&nbsp;
-			<span class="lg:flex">by</span><span class="text-violet-600 lg:flex font-extrabold ms-1"
-				>10x</span
-			>
-		</a>
-	</div>
-	<div id="help" class="hidden lg:flex ml-3">
-		<button
-			id="show-shortcuts-button"
-			class="hidden"
-			on:click={() => {
-				showShortcuts = !showShortcuts;
-			}}
-		/>
+<div class=" hidden lg:flex fixed bottom-0 right-0 px-2 py-2 z-20">
+	<button
+		id="show-shortcuts-button"
+		class="hidden"
+		on:click={() => {
+			showShortcuts = !showShortcuts;
+		}}
+	/>
 
-		<HelpMenu
-			showDocsHandler={() => {
-				showShortcuts = !showShortcuts;
-			}}
-			showShortcutsHandler={() => {
-				showShortcuts = !showShortcuts;
-			}}
-		>
-			<Tooltip content={$i18n.t('Help')} placement="left">
-				<button
-					class="text-gray-600 dark:text-gray-300 bg-gray-300/20 size-5 flex items-center justify-center text-[0.7rem] rounded-full"
-				>
-					?
-				</button>
-			</Tooltip>
-		</HelpMenu>
-	</div>
+	<HelpMenu
+		showDocsHandler={() => {
+			showShortcuts = !showShortcuts;
+		}}
+		showShortcutsHandler={() => {
+			showShortcuts = !showShortcuts;
+		}}
+	>
+		<Tooltip content={$i18n.t('Help')} placement="left">
+			<button
+				class="text-gray-600 dark:text-gray-300 bg-gray-300/20 size-5 flex items-center justify-center text-[0.7rem] rounded-full"
+			>
+				?
+			</button>
+		</Tooltip>
+	</HelpMenu>
 </div>
+
 <ShortcutsModal bind:show={showShortcuts} />

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -434,21 +434,6 @@
 								</button>
 							</div>
 						{/if}
-						<div class="inline-flex items-center justify-center w-full">
-							<hr class="w-32 h-px my-8 bg-gray-200 border-0 dark:bg-gray-700" />
-						</div>
-						<a href="https://10x.gsa.gov" target="_blank" rel="noopener noreferrer">
-							<div class=" text-sm text-center">
-								powered by
-								<img
-									crossorigin="anonymous"
-									src="{WEBUI_BASE_URL}/static/10x_ai.png"
-									class=" w-7 inline-block"
-									style="vertical-align: baseline;"
-									alt="10x AI"
-								/>
-							</div>
-						</a>
 					</div>
 				{/if}
 			</div>


### PR DESCRIPTION
There were 2 references to 10x in the UI and both were removed in this PR. The first was in the chat page and the other was on the login page. For the chat page, I rolled back changes that were made since standing up the project, and `src/lib/components/layout/Help.svelte` should now be back in sync with the upstream file.