### PR TITLE
address issue#174 hide version update 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,6 @@ ALLOW_SIMULTANEOUS_MODELS=false
 SCARF_NO_ANALYTICS=true
 DO_NOT_TRACK=true
 ANONYMIZED_TELEMETRY=false
+
+# Globally set default value for whether or not display the version update (admin user can change individual user setting on UI)
+DEFAULT_SHOW_VERSION_UPDATE=false

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,5 +1,5 @@
 {
-  "version": "1.4.0",
+  "version": "1.5.0",
   "plugins_used": [
     {
       "name": "ArtifactoryDetector"

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -947,6 +947,9 @@ ENABLE_MESSAGE_RATING = PersistentConfig(
 ALLOW_SIMULTANEOUS_MODELS = (
     os.environ.get("ALLOW_SIMULTANEOUS_MODELS", "True").lower() == "true"
 )
+DEFAULT_SHOW_VERSION_UPDATE = (
+    os.environ.get("DEFAULT_SHOW_VERSION_UPDATE", "False").lower() == "true"
+)
 
 
 def validate_cors_origins(origins):

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -217,7 +217,6 @@ from open_webui.config import (
     EVALUATION_ARENA_MODELS,
     DEFAULT_SHOW_VERSION_UPDATE,
     DEFAULT_SHOW_CHANGELOG,
-
     # WebUI (OAuth)
     ENABLE_OAUTH_ROLE_MANAGEMENT,
     OAUTH_ROLES_CLAIM,
@@ -988,7 +987,6 @@ async def get_app_config(request: Request):
             "enable_signup": app.state.config.ENABLE_SIGNUP,
             "enable_login_form": app.state.config.ENABLE_LOGIN_FORM,
             "enable_websocket": ENABLE_WEBSOCKET_SUPPORT,
-            "default_show_version_update": DEFAULT_SHOW_VERSION_UPDATE,
             **(
                 {
                     "enable_channels": app.state.config.ENABLE_CHANNELS,
@@ -1002,6 +1000,7 @@ async def get_app_config(request: Request):
                     "enable_admin_export": ENABLE_ADMIN_EXPORT,
                     "enable_admin_chat_access": ENABLE_ADMIN_CHAT_ACCESS,
                     "default_show_changelog": DEFAULT_SHOW_CHANGELOG,
+                    "default_show_version_update": DEFAULT_SHOW_VERSION_UPDATE,
                 }
                 if user is not None
                 else {}

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -213,6 +213,7 @@ from open_webui.config import (
     DEFAULT_ARENA_MODEL,
     MODEL_ORDER_LIST,
     EVALUATION_ARENA_MODELS,
+    DEFAULT_SHOW_VERSION_UPDATE,
     # WebUI (OAuth)
     ENABLE_OAUTH_ROLE_MANAGEMENT,
     OAUTH_ROLES_CLAIM,
@@ -983,6 +984,7 @@ async def get_app_config(request: Request):
             "enable_signup": app.state.config.ENABLE_SIGNUP,
             "enable_login_form": app.state.config.ENABLE_LOGIN_FORM,
             "enable_websocket": ENABLE_WEBSOCKET_SUPPORT,
+            "default_show_version_update": DEFAULT_SHOW_VERSION_UPDATE,
             **(
                 {
                     "enable_channels": app.state.config.ENABLE_CHANNELS,

--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -205,7 +205,8 @@
 		responseAutoCopy = $settings.responseAutoCopy ?? false;
 
 		showUsername = $settings.showUsername ?? false;
-		showUpdateToast = $settings.showUpdateToast ?? $config?.features.default_show_version_update?? true;
+		showUpdateToast =
+			$settings.showUpdateToast ?? $config?.features.default_show_version_update ?? true;
 		showChangelog = $settings.showChangelog ?? true;
 
 		showEmojiInCall = $settings.showEmojiInCall ?? false;

--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -205,7 +205,7 @@
 		responseAutoCopy = $settings.responseAutoCopy ?? false;
 
 		showUsername = $settings.showUsername ?? false;
-		showUpdateToast = $settings.showUpdateToast ?? true;
+		showUpdateToast = $settings.showUpdateToast ?? $config?.features.default_show_version_update?? true;
 		showChangelog = $settings.showChangelog ?? true;
 
 		showEmojiInCall = $settings.showEmojiInCall ?? false;

--- a/src/lib/components/chat/Settings/Interface.svelte
+++ b/src/lib/components/chat/Settings/Interface.svelte
@@ -211,7 +211,6 @@
 
 		showChangelog = $settings.showChangelog ?? $config?.features.default_show_changelog ?? true;
 
-
 		showEmojiInCall = $settings.showEmojiInCall ?? false;
 		voiceInterruption = $settings.voiceInterruption ?? false;
 

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -296,7 +296,7 @@
 		{/if}
 	</div>
 </div>
-{#if version && compareVersion(version.latest, version.current) && ($settings?.showUpdateToast ?? $config?.features.default_show_version_update?? true)}
+{#if version && compareVersion(version.latest, version.current) && ($settings?.showUpdateToast ?? $config?.features.default_show_version_update ?? true)}
 	<div class=" absolute bottom-8 right-8 z-50" in:fade={{ duration: 100 }}>
 		<UpdateInfoToast
 			{version}

--- a/src/routes/(app)/+layout.svelte
+++ b/src/routes/(app)/+layout.svelte
@@ -296,7 +296,7 @@
 		{/if}
 	</div>
 </div>
-{#if version && compareVersion(version.latest, version.current) && ($settings?.showUpdateToast ?? true)}
+{#if version && compareVersion(version.latest, version.current) && ($settings?.showUpdateToast ?? $config?.features.default_show_version_update?? true)}
 	<div class=" absolute bottom-8 right-8 z-50" in:fade={{ duration: 100 }}>
 		<UpdateInfoToast
 			{version}


### PR DESCRIPTION

### Description

- Address issue#174 Add env variable to set whether or not display the version update globally
- Admin user still can set "Toast notifications for new updates" on and off to overwrite the global setting

### Added

- Added environment var DEFAULT_SHOW_VERSION_UPDATE and set it default to be False

### Changed

- changed logic to show and hide version update based the combination of previous flags plus new flag.



