### PR TITLE
Plain language improvements

### DIFF
--- a/backend/open_webui/routers/chats.py
+++ b/backend/open_webui/routers/chats.py
@@ -452,7 +452,7 @@ async def clone_chat_by_id(id: str, user=Depends(get_verified_user)):
             **chat.chat,
             "originalChatId": chat.id,
             "branchPointMessageId": chat.chat["history"]["currentId"],
-            "title": f"Clone of {chat.title}",
+            "title": f"Duplicate of {chat.title}",
         }
 
         chat = Chats.insert_new_chat(user.id, ChatForm(**{"chat": updated_chat}))

--- a/backend/open_webui/test/apps/webui/routers/test_chats.py
+++ b/backend/open_webui/test/apps/webui/routers/test_chats.py
@@ -200,10 +200,10 @@ class TestChats(AbstractPostgresTest):
             "name": "chat1",
             "originalChatId": chat_id,
             "tags": ["tag1", "tag2"],
-            "title": "Clone of New Chat",
+            "title": "Duplicate of New Chat",
         }
         assert data["share_id"] is None
-        assert data["title"] == "Clone of New Chat"
+        assert data["title"] == "Duplicate of New Chat"
         assert data["user_id"] == "2"
 
     def test_archive_chat_by_id(self):

--- a/src/lib/i18n/locales/en-US/translation.json
+++ b/src/lib/i18n/locales/en-US/translation.json
@@ -165,7 +165,7 @@
 	"click here.": "",
 	"Click on the user role button to change a user's role.": "",
 	"Clipboard write permission denied. Please check your browser settings to grant the necessary access.": "",
-	"Clone": "",
+	"Clone": "Duplicate",
 	"Close": "",
 	"Code execution": "",
 	"Code formatted successfully": "",


### PR DESCRIPTION
Use 'Duplicate' terminology rather than 'Clone' per #209 