### PR TITLE
Hotfix - More robust healthcheck

### DIFF
--- a/backend/cohere_proxy/proxy.py
+++ b/backend/cohere_proxy/proxy.py
@@ -73,3 +73,26 @@ async def proxy_embeddings(request: Request):
     except Exception as e:
         logger.error(f"An error occurred: {e}")
         return JSONResponse(status_code=500, content={"error": "Internal server error"})
+
+
+@app.get("/health")
+async def health():
+    is_healthy = False
+    test_body = json.dumps({"texts": ["test"], "input_type": "search_query"})
+    try:
+        response = bedrock_client.invoke_model(
+            body=test_body,
+            modelId=model_id,
+            accept="application/json",
+            contentType="application/json",
+        )
+        response_body = json.loads(response.get("body").read())
+        embeddings = response_body.get("embeddings")
+        is_healthy = len(embeddings) > 0
+
+    except Exception as e:
+        logger.error(f"Cohere proxy health - error occurred: {e}")
+
+    return JSONResponse(
+        status_code=200 if is_healthy else 500, content={"ok": is_healthy}
+    )

--- a/backend/open-webui-pipelines/start.sh
+++ b/backend/open-webui-pipelines/start.sh
@@ -10,23 +10,23 @@ cd "$SCRIPT_DIR" || exit
 
 # PIPELINES_REQUIREMENTS_PATH=$SCRIPT_DIR/requirements.txt
 
-# Function to install requirements if requirements.txt is provided
-install_requirements() {
-  if [[ -f "$1" ]]; then
-    echo "requirements.txt found at $1. Installing requirements..."
-    pip3 install -r "$1"
-  else
-    echo "requirements.txt not found at $1. Skipping installation of requirements."
-  fi
-}
+# # Function to install requirements if requirements.txt is provided
+# install_requirements() {
+#   if [[ -f "$1" ]]; then
+#     echo "requirements.txt found at $1. Installing requirements..."
+#     pip3 install -r "$1"
+#   else
+#     echo "requirements.txt not found at $1. Skipping installation of requirements."
+#   fi
+# }
 
-# Check if the PIPELINES_REQUIREMENTS_PATH environment variable is set and non-empty
-if [[ -n "$PIPELINES_REQUIREMENTS_PATH" ]]; then
-  # Install requirements from the specified requirements.txt
-  install_requirements "$PIPELINES_REQUIREMENTS_PATH"
-else
-  echo "PIPELINES_REQUIREMENTS_PATH not specified. Skipping installation of requirements."
-fi
+# # Check if the PIPELINES_REQUIREMENTS_PATH environment variable is set and non-empty
+# if [[ -n "$PIPELINES_REQUIREMENTS_PATH" ]]; then
+#   # Install requirements from the specified requirements.txt
+#   install_requirements "$PIPELINES_REQUIREMENTS_PATH"
+# else
+#   echo "PIPELINES_REQUIREMENTS_PATH not specified. Skipping installation of requirements."
+# fi
 
 PIPELINES_DIR=$SCRIPT_DIR/pipelines
 

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -3,19 +3,22 @@
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 cd "$SCRIPT_DIR" || exit
 
-# runs on 9100
-# ./azure_proxy/start.sh &
-
 # Function to check if a port is in use
 is_port_in_use() {
   lsof -i :"$1" >/dev/null
 }
 
-# Check if port 9100 is in use
+# # Check if port 9100 is in use
+# if is_port_in_use 9100; then
+#   echo "POD [$HOSTNAME] - Port 9100 is already in use. Skipping cohere proxy start." >&2
+# else
+#   ./azure_proxy/start.sh &
+# fi
+
+# Check if port 9101 is in use
 if is_port_in_use 9101; then
-  echo "POD [$HOSTNAME] - Port 9100 is already in use. Skipping cohere proxy start." >&2
+  echo "POD [$HOSTNAME] - Port 9101 is already in use. Skipping cohere proxy start." >&2
 else
-  # run on 9100
   ./cohere_proxy/start.sh &
 fi
 
@@ -23,7 +26,6 @@ fi
 if is_port_in_use 9099; then
   echo "POD [$HOSTNAME] - Port 9099 is already in use. Skipping open webui pipelines server start." >&2
 else
-  # runs on 9099
   ./open-webui-pipelines/start.sh &
 fi
 

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -3,9 +3,29 @@
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 cd "$SCRIPT_DIR" || exit
 
-./azure_proxy/start.sh &
-./cohere_proxy/start.sh &
-./open-webui-pipelines/start.sh &
+# runs on 9100
+# ./azure_proxy/start.sh &
+
+# Function to check if a port is in use
+is_port_in_use() {
+  lsof -i :"$1" >/dev/null
+}
+
+# Check if port 9100 is in use
+if is_port_in_use 9101; then
+  echo "POD [$HOSTNAME] - Port 9100 is already in use. Skipping cohere proxy start." >&2
+else
+  # run on 9100
+  ./cohere_proxy/start.sh &
+fi
+
+# Check if port 9099 is in use
+if is_port_in_use 9099; then
+  echo "POD [$HOSTNAME] - Port 9099 is already in use. Skipping open webui pipelines server start." >&2
+else
+  # runs on 9099
+  ./open-webui-pipelines/start.sh &
+fi
 
 KEY_FILE=.webui_secret_key
 

--- a/start.sh
+++ b/start.sh
@@ -4,8 +4,7 @@
 # ollama serve &
 
 # Start the application
-printenv
-./backend/open-webui-pipelines/start.sh &
+# printenv
 ./backend/start.sh &
 
 # Wait for all background processes to exit


### PR DESCRIPTION
Add robust healthcheck at /health to ensure we are ready for connections. 

Note: This should only be hit during startup. We're using the default route for the liveness check.