### PR TITLE
Add screen reader announcements for chat response loading 

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -815,6 +815,11 @@
 	};
 
 	const chatCompletedHandler = async (chatId, modelId, responseMessageId, messages) => {
+		// SR announcement
+		document.getElementById('svelte-announcer').textContent = 'response generated';
+
+		// TODO: refocus to last message here
+
 		const res = await chatCompleted(localStorage.token, {
 			model: modelId,
 			messages: messages.map((m) => ({
@@ -1203,6 +1208,8 @@
 
 	const submitPrompt = async (userPrompt, { _raw = false } = {}) => {
 		console.debug('submitPrompt', userPrompt, $chatId);
+		// SR announcement
+		document.getElementById('svelte-announcer').textContent = 'response is loading';
 
 		const messages = createMessagesList(history.currentId);
 		const _selectedModels = selectedModels.map((modelId) =>

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -819,6 +819,7 @@
 		document.getElementById('svelte-announcer').textContent = 'response generated';
 
 		// TODO: refocus to last message here
+		document.getElementById(`message-${responseMessageId}-content`)?.querySelector("#response-content-container")?.focus();
 
 		const res = await chatCompleted(localStorage.token, {
 			model: modelId,

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -818,8 +818,11 @@
 		// SR announcement
 		document.getElementById('svelte-announcer').textContent = 'response generated';
 
-		// TODO: refocus to last message here
-		document.getElementById(`message-${responseMessageId}-content`)?.querySelector("#response-content-container")?.focus();
+		// Refocus to last message
+		document
+			.getElementById(`message-${responseMessageId}-content`)
+			?.querySelector('#response-content-container')
+			?.focus();
 
 		const res = await chatCompleted(localStorage.token, {
 			model: modelId,

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -513,7 +513,10 @@
 					</div>
 				{/if}
 
-				<div class="chat-{message.role} w-full min-w-full markdown-prose">
+				<div
+					class="chat-{message.role} w-full min-w-full markdown-prose"
+					id="message-{message.id}-content"
+				>
 					<div>
 						{#if (message?.statusHistory ?? [...(message?.status ? [message?.status] : [])]).length > 0}
 							{@const status = (
@@ -653,7 +656,12 @@
 								</div>
 							</div>
 						{:else}
-							<div class="w-full flex flex-col relative" id="response-content-container">
+							<div
+								class="w-full flex flex-col relative"
+								id="response-content-container"
+								tabindex="0"
+							>
+								<h2 class="sr-only">{model?.name ?? message.model} says:</h2>
 								{#if message.content === '' && !message.error}
 									<Skeleton />
 								{:else if message.content && message.error !== true}


### PR DESCRIPTION
# Pull Request Checklist

### Description

- Injects "response is loading" and "response generated" into the svelte announcer
- Adds visibly hidden `h2` to top of latest response
- Re-focuses to top of latest response when chat is done loading it

### How to test

On a mac, turn on VoiceOver and start chatting. You should notice "response is loading" and "response generated" announcements, as well as a "[Model] says:" announcement when re-focused.
