### PR TITLE
Auto formatting for Python files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -307,7 +307,6 @@ dist
 # cypress artifacts
 cypress/videos
 cypress/screenshots
-.vscode/settings.json
 
 # # github
 # # .github/
@@ -323,6 +322,5 @@ cypress/screenshots
 # update_ollama_models.sh
 # # Caddyfile.localhost
 # # hatch_build
-
 
 .routes-*

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -27,5 +27,5 @@ kill $spinner_pid
 
 npm install
 npm run format
+npm run format:backend
 npm run i18n:parse
-git add .

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+	"recommendations": ["ms-python.black-formatter"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+	"editor.formatOnSave": true,
+	"[python]": {
+		"editor.defaultFormatter": "ms-python.black-formatter"
+	}
+}

--- a/pre-commit
+++ b/pre-commit
@@ -27,4 +27,5 @@ kill $spinner_pid
 
 npm install
 npm run format
+npm run format:backend
 npm run i18n:parse


### PR DESCRIPTION
Improve pre-commit Python formatting per #213.

This does a few things so far:
- If you're using VS Code or a VS Code based editor, it should recommend the Black Formatter extension upon startup
- Enables format-on-save for Python files using Black
- Updates the pre-commit hook to run Black (which, if you're using VS Code, shouldn't have any changes left to make)

To get this to work:
1. Ensure you have [Black Formatter](https://marketplace.cursorapi.com/items?itemName=ms-python.black-formatter) installed (hopefully if you're using VS Code, it'll prompt you to do so if you don't already have it; let me know if it doesn't prompt you)
2. `cp pre-commit .husky/pre-commit` to make sure Husky has the latest pre-commit configuration