### PR TITLE
address issue#268, added feature flag to show and hide ask and explain floating buttons

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,6 @@ ENABLE_MORE_INPUTS=false
 
 # show/hide disclaimer at the bottm (default = true)
 ENABLE_DISCLAIMER=true
+
+# show/hide floating buttons (ask and explain) in response message (default:false)
+ENABLE_FLOATING_BUTTONS=false

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -963,7 +963,12 @@ ENABLE_ADMIN_FEEDBACKS = (
 ENABLE_RECORD_VOICE_AND_CALL = (
     os.environ.get("ENABLE_RECORD_VOICE_AND_CALL", "False").lower() == "true"
 )
+
 ENABLE_DISCLAIMER = os.environ.get("ENABLE_DISCLAIMER", "True").lower() == "true"
+
+ENABLE_FLOATING_BUTTONS = (
+    os.environ.get("ENABLE_FLOATING_BUTTONS", "False").lower() == "true"
+)
 
 
 def validate_cors_origins(origins):

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -223,6 +223,7 @@ from open_webui.config import (
     ENABLE_RECORD_VOICE_AND_CALL,
     ENABLE_MORE_INPUTS,
     ENABLE_DISCLAIMER,
+    ENABLE_FLOATING_BUTTONS,
     # WebUI (OAuth)
     ENABLE_OAUTH_ROLE_MANAGEMENT,
     OAUTH_ROLES_CLAIM,
@@ -1013,6 +1014,7 @@ async def get_app_config(request: Request):
                     "enable_record_voice_and_call": ENABLE_RECORD_VOICE_AND_CALL,
                     "enable_more_inputs": ENABLE_MORE_INPUTS,
                     "enable_disclaimer": ENABLE_DISCLAIMER,
+                    "enable_floating_buttons": ENABLE_FLOATING_BUTTONS,
                 }
                 if user is not None
                 else {}

--- a/src/lib/components/chat/Messages/ContentRenderer.svelte
+++ b/src/lib/components/chat/Messages/ContentRenderer.svelte
@@ -4,7 +4,7 @@
 	const dispatch = createEventDispatcher();
 
 	import Markdown from './Markdown.svelte';
-	import { chatId, mobile, showArtifacts, showControls, showOverview } from '$lib/stores';
+	import { chatId, mobile, showArtifacts, showControls, showOverview, config } from '$lib/stores';
 	import FloatingButtons from '../ContentRenderer/FloatingButtons.svelte';
 	import { createMessagesList } from '$lib/utils';
 
@@ -159,7 +159,7 @@
 	/>
 </div>
 
-{#if floatingButtons && model}
+{#if $config?.features.enable_floating_buttons && floatingButtons && model}
 	<FloatingButtons
 		bind:this={floatingButtonsElement}
 		{id}


### PR DESCRIPTION
### Description

- address issue [#268](https://github.com/GSA-TTS/10x-ai-sandbox/issues/268), added feature flag to show and hide "ask and explain" floating buttons

### Added

- feature flag to show and hide floating buttons

### Changed

- default to hide floating buttons ( ask and explain)

### Screenshots or Videos

- Before: highlight chat response, ask and explain button will show up
<img width="454" alt="image" src="https://github.com/user-attachments/assets/34ab8323-2803-4f0a-8a0e-5886abeb612e" />

- After: 
<img width="741" alt="image" src="https://github.com/user-attachments/assets/fa007b3e-4b3a-4f11-b9c3-e7addbd4b447" />
