### PR TITLE
Add a feature flag for the chat Delete button

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -46,3 +46,9 @@ ENABLE_MORE_INPUTS=false
 
 # show/hide disclaimer at the bottm (default = true)
 ENABLE_DISCLAIMER=true
+
+# Show/hide the Delete button in the chat menu (default: false)
+ENABLE_DELETE_BUTTON=false
+# Note: If you disable the delete button, you might also want to set
+# USER_PERMISSIONS_CHAT_DELETE=false to disable user chat deletion via the API.
+USER_PERMISSIONS_CHAT_DELETE=false

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -972,6 +972,7 @@ ENABLE_FLOATING_BUTTONS = (
 
 ENABLE_DELETE_BUTTON = os.environ.get("ENABLE_DELETE_BUTTON", "False").lower() == "true"
 
+
 def validate_cors_origins(origins):
     for origin in origins:
         if origin != "*":

--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -965,6 +965,7 @@ ENABLE_RECORD_VOICE_AND_CALL = (
 )
 ENABLE_DISCLAIMER = os.environ.get("ENABLE_DISCLAIMER", "True").lower() == "true"
 
+ENABLE_DELETE_BUTTON = os.environ.get("ENABLE_DELETE_BUTTON", "False").lower() == "true"
 
 def validate_cors_origins(origins):
     for origin in origins:

--- a/backend/open_webui/main.py
+++ b/backend/open_webui/main.py
@@ -223,6 +223,7 @@ from open_webui.config import (
     ENABLE_RECORD_VOICE_AND_CALL,
     ENABLE_MORE_INPUTS,
     ENABLE_DISCLAIMER,
+    ENABLE_DELETE_BUTTON,
     # WebUI (OAuth)
     ENABLE_OAUTH_ROLE_MANAGEMENT,
     OAUTH_ROLES_CLAIM,
@@ -1013,6 +1014,7 @@ async def get_app_config(request: Request):
                     "enable_record_voice_and_call": ENABLE_RECORD_VOICE_AND_CALL,
                     "enable_more_inputs": ENABLE_MORE_INPUTS,
                     "enable_disclaimer": ENABLE_DISCLAIMER,
+                    "enable_delete_button": ENABLE_DELETE_BUTTON,
                 }
                 if user is not None
                 else {}

--- a/src/lib/components/layout/Sidebar/ChatMenu.svelte
+++ b/src/lib/components/layout/Sidebar/ChatMenu.svelte
@@ -23,7 +23,7 @@
 		getChatPinnedStatusById,
 		toggleChatPinnedStatusById
 	} from '$lib/apis/chats';
-	import { chats } from '$lib/stores';
+	import { config } from '$lib/stores';
 	import { createMessagesList } from '$lib/utils';
 	import { downloadChatAsPDF } from '$lib/apis/utils';
 	import Download from '$lib/components/icons/Download.svelte';
@@ -235,15 +235,17 @@
 					</DropdownMenu.Item>
 				</DropdownMenu.SubContent>
 			</DropdownMenu.Sub>
-			<DropdownMenu.Item
-				class="flex  gap-2  items-center px-3 py-1.5 text-sm  cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-md"
-				on:click={() => {
-					deleteHandler();
-				}}
-			>
-				<GarbageBin strokeWidth="2" />
-				<div class="flex items-center">{$i18n.t('Delete')}</div>
-			</DropdownMenu.Item>
+			{#if $config?.features?.enable_delete_button}
+				<DropdownMenu.Item
+					class="flex  gap-2  items-center px-3 py-1.5 text-sm  cursor-pointer hover:bg-gray-50 dark:hover:bg-gray-800 rounded-md"
+					on:click={() => {
+						deleteHandler();
+					}}
+				>
+					<GarbageBin strokeWidth="2" />
+					<div class="flex items-center">{$i18n.t('Delete')}</div>
+				</DropdownMenu.Item>
+			{/if}
 
 			<hr class="border-gray-50 dark:border-gray-850 my-0.5" />
 

--- a/src/lib/stores/index.ts
+++ b/src/lib/stores/index.ts
@@ -207,6 +207,7 @@ type Config = {
 		default_show_version_update: boolean;
 		enable_record_voice_and_call: boolean;
 		enable_disclaimer: boolean;
+		enable_delete_button: boolean;
 	};
 	oauth: {
 		providers: {


### PR DESCRIPTION
Per #270, add a feature flag to show or hide the Delete button in the chat dropdown.

The `ENABLE_DELETE_BUTTON` flag only shows and hides the option in the UI. The `USER_PERMISSIONS_CHAT_DELETE` environment variable should also be set to `false` to prevent chat deletion by users via the API as well.