### PR TITLE
Fix failing pg migration test, remove sqlite/mysql tests

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -111,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       postgres:
-        image: postgres
+        image: pgvector/pgvector:pg15
         env:
           POSTGRES_PASSWORD: postgres # pragma: allowlist secret
         options: >-

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -149,6 +149,7 @@ jobs:
           WEBUI_SECRET_KEY: secret-key  # pragma: allowlist secret
           GLOBAL_LOG_LEVEL: debug
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres  # pragma: allowlist secret
+          PGVECTOR_DB_URL: postgresql+psycopg2://postgres:postgres@localhost:5432/postgres # pragma: allowlist secret
           DATABASE_POOL_SIZE: 10
           DATABASE_POOL_MAX_OVERFLOW: 10
           DATABASE_POOL_TIMEOUT: 30

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -121,18 +121,6 @@ jobs:
           --health-retries 5
         ports:
           - 5432:5432
-    #      mysql:
-    #        image: mysql
-    #        env:
-    #          MYSQL_ROOT_PASSWORD: mysql
-    #          MYSQL_DATABASE: mysql
-    #        options: >-
-    #          --health-cmd "mysqladmin ping -h localhost"
-    #          --health-interval 10s
-    #          --health-timeout 5s
-    #          --health-retries 5
-    #        ports:
-    #          - 3306:3306
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
@@ -156,34 +144,7 @@ jobs:
         run: |
           uv pip install -r backend/requirements.txt
 
-      - name: Test backend with SQLite
-        id: sqlite
-        env:
-          WEBUI_SECRET_KEY: secret-key # pragma: allowlist secret
-          GLOBAL_LOG_LEVEL: debug
-        run: |
-          cd backend
-          uvicorn open_webui.main:app --port "8080" --forwarded-allow-ips '*' &
-          UVICORN_PID=$!
-          # Wait up to 40 seconds for the server to start
-          for i in {1..40}; do
-              curl -s http://localhost:8080/api/config > /dev/null && break
-              sleep 1
-              if [ $i -eq 40 ]; then
-                  echo "Server failed to start"
-                  kill -9 $UVICORN_PID
-                  exit 1
-              fi
-          done
-          # Check that the server is still running after 5 seconds
-          sleep 5
-          if ! kill -0 $UVICORN_PID; then
-              echo "Server has stopped"
-              exit 1
-          fi
-
       - name: Test backend with Postgres
-        if: success() || steps.sqlite.conclusion == 'failure'
         env:
           WEBUI_SECRET_KEY: secret-key  # pragma: allowlist secret
           GLOBAL_LOG_LEVEL: debug
@@ -230,30 +191,3 @@ jobs:
             echo "Server has not reconnected to postgres after connection was closed: returned status $status_code"
             exit 1
           fi
-
-#      - name: Test backend with MySQL
-#        if: success() || steps.sqlite.conclusion == 'failure' || steps.postgres.conclusion == 'failure'
-#        env:
-#          WEBUI_SECRET_KEY: secret-key
-#          GLOBAL_LOG_LEVEL: debug
-#          DATABASE_URL: mysql://root:mysql@localhost:3306/mysql
-#        run: |
-#          cd backend
-#          uvicorn open_webui.main:app --port "8083" --forwarded-allow-ips '*' &
-#          UVICORN_PID=$!
-#          # Wait up to 20 seconds for the server to start
-#          for i in {1..20}; do
-#              curl -s http://localhost:8083/api/config > /dev/null && break
-#              sleep 1
-#              if [ $i -eq 20 ]; then
-#                  echo "Server failed to start"
-#                  kill -9 $UVICORN_PID
-#                  exit 1
-#              fi
-#          done
-#          # Check that the server is still running after 5 seconds
-#          sleep 5
-#          if ! kill -0 $UVICORN_PID; then
-#              echo "Server has stopped"
-#              exit 1
-#          fi


### PR DESCRIPTION
use pgvector in migration test now that it is the default VECTOR_DB