### PR TITLE
load prompt configs in admin interface api

### DIFF
--- a/backend/open_webui/routers/tasks.py
+++ b/backend/open_webui/routers/tasks.py
@@ -58,7 +58,7 @@ async def get_task_config(request: Request, user=Depends(get_verified_user)):
         "ENABLE_RETRIEVAL_QUERY_GENERATION": request.app.state.config.ENABLE_RETRIEVAL_QUERY_GENERATION,
         "QUERY_GENERATION_PROMPT_TEMPLATE": request.app.state.config.QUERY_GENERATION_PROMPT_TEMPLATE,
         "TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE": request.app.state.config.TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE,
-        "DEFAULT_PROMPT_SUGGESTIONS": request.app.state.config.DEFAULT_PROMPT_SUGGESTIONS
+        "DEFAULT_PROMPT_SUGGESTIONS": request.app.state.config.DEFAULT_PROMPT_SUGGESTIONS,
     }
 
 

--- a/backend/open_webui/routers/tasks.py
+++ b/backend/open_webui/routers/tasks.py
@@ -58,6 +58,7 @@ async def get_task_config(request: Request, user=Depends(get_verified_user)):
         "ENABLE_RETRIEVAL_QUERY_GENERATION": request.app.state.config.ENABLE_RETRIEVAL_QUERY_GENERATION,
         "QUERY_GENERATION_PROMPT_TEMPLATE": request.app.state.config.QUERY_GENERATION_PROMPT_TEMPLATE,
         "TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE": request.app.state.config.TOOLS_FUNCTION_CALLING_PROMPT_TEMPLATE,
+        "DEFAULT_PROMPT_SUGGESTIONS": request.app.state.config.DEFAULT_PROMPT_SUGGESTIONS
     }
 
 

--- a/src/lib/components/admin/Settings/Interface.svelte
+++ b/src/lib/components/admin/Settings/Interface.svelte
@@ -49,7 +49,6 @@
 	onMount(async () => {
 		taskConfig = await getTaskConfig(localStorage.token);
 
-		// promptSuggestions = $config?.default_prompt_suggestions;
 		promptSuggestions = taskConfig.DEFAULT_PROMPT_SUGGESTIONS;
 		banners = await getBanners(localStorage.token);
 	});

--- a/src/lib/components/admin/Settings/Interface.svelte
+++ b/src/lib/components/admin/Settings/Interface.svelte
@@ -30,7 +30,8 @@
 		ENABLE_TAGS_GENERATION: true,
 		ENABLE_SEARCH_QUERY_GENERATION: true,
 		ENABLE_RETRIEVAL_QUERY_GENERATION: true,
-		QUERY_GENERATION_PROMPT_TEMPLATE: ''
+		QUERY_GENERATION_PROMPT_TEMPLATE: '',
+		DEFAULT_PROMPT_SUGGESTIONS: []
 	};
 
 	let promptSuggestions = [];
@@ -48,7 +49,8 @@
 	onMount(async () => {
 		taskConfig = await getTaskConfig(localStorage.token);
 
-		promptSuggestions = $config?.default_prompt_suggestions;
+		// promptSuggestions = $config?.default_prompt_suggestions;
+		promptSuggestions = taskConfig.DEFAULT_PROMPT_SUGGESTIONS;
 		banners = await getBanners(localStorage.token);
 	});
 


### PR DESCRIPTION
This address an issue where prompt suggestions were not present on the the object returned by the config api endpoint that populates `interface` tab of the admin panel. The panel was instead loading from local storage, which can lead to the value being out of date and overwriting newer values.

This does not fix the concurrency problems around multiple admin users changing values simultaneously, but helps insure that when an admin goes to the interface tab, they will at least retrieve the most recent prompt suggestions.