### PR TITLE
Express rate limit errors to users via chat response

### DIFF
--- a/backend/cohere_proxy/dev.sh
+++ b/backend/cohere_proxy/dev.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+cd "$SCRIPT_DIR" || exit
+lsof -ti:9101 | xargs kill -9
+uvicorn proxy:app --host 0.0.0.0 --port 9101 --reload --forwarded-allow-ips '*'

--- a/backend/cohere_proxy/start.sh
+++ b/backend/cohere_proxy/start.sh
@@ -2,9 +2,4 @@
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 cd "$SCRIPT_DIR" || exit
 
-if [ "${DEV:-false}" ]; then
-    $SCRIPT_DIR/dev.sh
-else
-    uvicorn proxy:app --host 0.0.0.0 --port 9101 --forwarded-allow-ips '*'
-fi
-
+uvicorn proxy:app --host 0.0.0.0 --port 9101 --forwarded-allow-ips '*'

--- a/backend/cohere_proxy/start.sh
+++ b/backend/cohere_proxy/start.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 cd "$SCRIPT_DIR" || exit
-uvicorn proxy:app --host 0.0.0.0 --port 9101 --reload --forwarded-allow-ips '*'
+
+if [ "${DEV:-false}" ]; then
+    $SCRIPT_DIR/dev.sh
+else
+    uvicorn proxy:app --host 0.0.0.0 --port 9101 --forwarded-allow-ips '*'
+fi
+

--- a/backend/dev.sh
+++ b/backend/dev.sh
@@ -1,2 +1,3 @@
 PORT="${PORT:-8080}"
+lsof -ti:$PORT | xargs kill -9
 uvicorn open_webui.main:app --port $PORT --host 0.0.0.0 --forwarded-allow-ips '*' --reload

--- a/backend/dev.sh
+++ b/backend/dev.sh
@@ -1,3 +1,6 @@
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+cd "$SCRIPT_DIR" || exit
+
 PORT="${PORT:-8080}"
 lsof -ti:$PORT | xargs kill -9
 uvicorn open_webui.main:app --port $PORT --host 0.0.0.0 --forwarded-allow-ips '*' --reload

--- a/backend/open_webui_pipelines/dev.sh
+++ b/backend/open_webui_pipelines/dev.sh
@@ -1,2 +1,3 @@
 PORT="${PORT:-9099}"
+lsof -ti:$PORT | xargs kill -9
 uvicorn main:app --port $PORT --host 0.0.0.0 --forwarded-allow-ips '*' --reload

--- a/backend/open_webui_pipelines/dev.sh
+++ b/backend/open_webui_pipelines/dev.sh
@@ -1,3 +1,6 @@
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+cd "$SCRIPT_DIR" || exit
+
 PORT="${PORT:-9099}"
 lsof -ti:$PORT | xargs kill -9
 uvicorn main:app --port $PORT --host 0.0.0.0 --forwarded-allow-ips '*' --reload

--- a/backend/open_webui_pipelines/pipelines/bedrock_claude_haiku35_pipeline_mock.py
+++ b/backend/open_webui_pipelines/pipelines/bedrock_claude_haiku35_pipeline_mock.py
@@ -1,6 +1,5 @@
 # import datetime
 import time
-import json
 import os
 from typing import Generator, Iterator, List, Optional, Union
 

--- a/backend/open_webui_pipelines/pipelines/bedrock_claude_sonnet35_v2_pipeline.py
+++ b/backend/open_webui_pipelines/pipelines/bedrock_claude_sonnet35_v2_pipeline.py
@@ -2,9 +2,9 @@ import json
 import os
 from typing import Generator, Iterator, List, Optional, Union
 
-import requests
 from pydantic import BaseModel
 from utils.pipelines.aws import bedrock_client
+from botocore.exceptions import BotoCoreError
 
 
 class Pipeline:
@@ -17,7 +17,7 @@ class Pipeline:
         self.valves = self.Valves(
             **{
                 "AWS_REGION": os.getenv("AWS_REGION", "us-east-1"),
-                "BEDROCK_CLAUDE_ARN": os.getenv("BEDROCK_CLAUDE_ARN", None),
+                "BEDROCK_CLAUDE_ARN": os.getenv("BEDROCK_CLAUDE_SONNET_35_ARN", None),
             }
         )
         self.bedrock_client = bedrock_client
@@ -108,6 +108,9 @@ class Pipeline:
                             }
                             del content["image_url"]
 
+        generic_error_msg = f"## Oops! 🤖💔\n\n ### GSA Chat is having some trouble.\n\nPlease try another model _or_ wait a minute and try again."  # noqa E501
+        rate_limit_error_msg = f"## Oops! 🤖💔\n\n ### Looks like GSA Chat has hit a service limit.\n\nPlease try another model _or_ wait a minute and try again."  # noqa E501
+
         try:
             r = self.bedrock_client.invoke_model_with_response_stream(
                 body=json.dumps(filtered_body), modelId=model_id
@@ -118,20 +121,42 @@ class Pipeline:
                 if chunk["type"] == "content_block_delta":
                     yield chunk["delta"].get("text", "")
 
-        except requests.exceptions.HTTPError as e:  # This will catch HTTP errors
-            if r.status_code == 400:
-                print(f"400 Bad Request received: {r.text}")
-            else:
-                print(f"HTTP Error: {e} Response: {r.text}")
-            return f"Error with r: {e} ({r.text}) for body:\n{body}\nand filtered_body:\n{filtered_body}"
-        except requests.exceptions.HTTPError as e:  # This will catch HTTP errors
-            if r.status_code == 400:
-                print(f"400 Bad Request received: {r.text}")
-            else:
-                print(f"HTTP Error: {e} Response: {r.text}")
-            return f"Error with r: {e} ({r.text}) for body:\n{body}\nand filtered_body:\n{filtered_body}"
+        except self.bedrock_client.exceptions.AccessDeniedException as e:
+            print("Access Denied Exception:", e)
+            yield generic_error_msg
+        except self.bedrock_client.exceptions.ResourceNotFoundException as e:
+            print("Resource Not Found Exception:", e)
+            yield generic_error_msg
+        except self.bedrock_client.exceptions.ThrottlingException as e:
+            print("Throttling Exception:", e)
+            yield rate_limit_error_msg
+        except self.bedrock_client.exceptions.ModelTimeoutException as e:
+            print("Model Timeout Exception:", e)
+            yield generic_error_msg
+        except self.bedrock_client.exceptions.InternalServerException as e:
+            print("Internal Server Exception:", e)
+            yield generic_error_msg
+        except self.bedrock_client.exceptions.ServiceUnavailableException as e:
+            print("Service Unavailable Exception:", e)
+            yield generic_error_msg
+        except self.bedrock_client.exceptions.ModelStreamErrorException as e:
+            print("Model Stream Error Exception:", e)
+            yield generic_error_msg
+        except self.bedrock_client.exceptions.ValidationException as e:
+            print("Validation Exception:", e)
+            yield generic_error_msg
+        except self.bedrock_client.exceptions.ModelNotReadyException as e:
+            print("Model Not Ready Exception:", e)
+            yield generic_error_msg
+        except self.bedrock_client.exceptions.ServiceQuotaExceededException as e:
+            print(f"Service Quota Exceeded Exception: {e}")
+            yield rate_limit_error_msg
+        except self.bedrock_client.exceptions.ModelErrorException as e:
+            print("Model Error Exception:", e)
+            yield generic_error_msg
+        except BotoCoreError as e:
+            print(f"AWS BotoCoreError: {e}")
+            yield generic_error_msg
         except Exception as e:
-            print(
-                f"Error without r: {e} for body:\n{body}\nand filtered_body:\n{filtered_body}"
-            )
-            return f"Error without r: {e} for body:\n{body}\nand filtered_body:\n{filtered_body}"
+            print(f"General Error: {e}")
+            yield generic_error_msg

--- a/backend/open_webui_pipelines/start.sh
+++ b/backend/open_webui_pipelines/start.sh
@@ -5,55 +5,6 @@ HOST="${HOST:-0.0.0.0}"
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 cd "$SCRIPT_DIR" || exit
 
-# Default value for PIPELINES_DIR
-# PIPELINES_DIR=${PIPELINES_DIR:-./pipelines}
-
-# PIPELINES_REQUIREMENTS_PATH=$SCRIPT_DIR/requirements.txt
-
-# # Function to install requirements if requirements.txt is provided
-# install_requirements() {
-#   if [[ -f "$1" ]]; then
-#     echo "requirements.txt found at $1. Installing requirements..."
-#     pip3 install -r "$1"
-#   else
-#     echo "requirements.txt not found at $1. Skipping installation of requirements."
-#   fi
-# }
-
-# # Check if the PIPELINES_REQUIREMENTS_PATH environment variable is set and non-empty
-# if [[ -n "$PIPELINES_REQUIREMENTS_PATH" ]]; then
-#   # Install requirements from the specified requirements.txt
-#   install_requirements "$PIPELINES_REQUIREMENTS_PATH"
-# else
-#   echo "PIPELINES_REQUIREMENTS_PATH not specified. Skipping installation of requirements."
-# fi
-
-PIPELINES_DIR=$SCRIPT_DIR/pipelines
-
-# Function to reset pipelines
-reset_pipelines_dir() {
-  if [ "$RESET_PIPELINES_DIR" = true ]; then
-    echo "Resetting pipelines directory: $PIPELINES_DIR"
-
-    # Check if the directory exists
-    if [ -d "$PIPELINES_DIR" ]; then
-      # Remove all contents of the directory
-      rm -rf "${PIPELINES_DIR:?}"/*
-      echo "All contents in $PIPELINES_DIR have been removed."
-
-      # Optionally recreate the directory if needed
-      mkdir -p "$PIPELINES_DIR"
-      echo "$PIPELINES_DIR has been recreated."
-    else
-      echo "Directory $PIPELINES_DIR does not exist. No action taken."
-    fi
-  else
-    echo "RESET_PIPELINES_DIR is not set to true. No action taken."
-  fi
-}
-
-# Example usage of the function
-reset_pipelines_dir
 
 # Function to download the pipeline files
 download_pipelines() {
@@ -131,5 +82,8 @@ else
   echo "PIPELINES_URLS not specified. Skipping pipelines download and installation."
 fi
 
-# Start the server
+if [ "${DEV:-false}" ]; then
+  $SCRIPT_DIR/dev.sh
+else
 uvicorn main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*'
+fi

--- a/backend/open_webui_pipelines/start.sh
+++ b/backend/open_webui_pipelines/start.sh
@@ -82,8 +82,4 @@ else
   echo "PIPELINES_URLS not specified. Skipping pipelines download and installation."
 fi
 
-if [ "${DEV:-false}" ]; then
-  $SCRIPT_DIR/dev.sh
-else
 uvicorn main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*'
-fi

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -11,4 +11,10 @@ if [ -z "$WEBUI_SECRET_KEY" ]; then
   WEBUI_SECRET_KEY=$(sed -n 's/^WEBUI_SECRET_KEY=//p' ../.env)
 fi
 
-WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec uvicorn open_webui.main:app --host "$HOST" --port "$PORT" --forwarded-allow-ips '*'
+if [ "${DEV:-false}" ]; then
+  $SCRIPT_DIR/dev.sh
+else
+  WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec uvicorn open_webui.main:app --host "$HOST" --port "$PORT"     --forwarded-allow-ips '*'
+fi
+
+

--- a/backend/start.sh
+++ b/backend/start.sh
@@ -11,10 +11,4 @@ if [ -z "$WEBUI_SECRET_KEY" ]; then
   WEBUI_SECRET_KEY=$(sed -n 's/^WEBUI_SECRET_KEY=//p' ../.env)
 fi
 
-if [ "${DEV:-false}" ]; then
-  $SCRIPT_DIR/dev.sh
-else
-  WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec uvicorn open_webui.main:app --host "$HOST" --port "$PORT"     --forwarded-allow-ips '*'
-fi
-
-
+WEBUI_SECRET_KEY="$WEBUI_SECRET_KEY" exec uvicorn open_webui.main:app --host "$HOST" --port "$PORT"     --forwarded-allow-ips '*'

--- a/dev.sh
+++ b/dev.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+./backend/open_webui_pipelines/dev.sh &
+./backend/cohere_proxy/dev.sh &
+./backend/dev.sh &
+
+wait


### PR DESCRIPTION
Express rate limit errors to users via chat response. Detect DEV env var in start script and run dev.sh instead.

This PR will require the following env vars to be set:

BEDROCK_LLAMA3211B_ARN (unchanged)

BEDROCK_CLAUDE_SONNET_35_ARN

BEDROCK_CLAUDE_SONNET_37_ARN

BEDROCK_CLAUDE_HAIKU_35_ARN

Added [this issue](https://github.com/GSA-TTS/10x-ai-sandbox/issues/314) to resolve logging in pipelines server.