### PR TITLE
bring gsa logo back

### DIFF
--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -496,9 +496,9 @@
 					<div class="self-center">
 						<img
 							crossorigin="anonymous"
-							src="{WEBUI_BASE_URL}/static/favicon.png"
-							class=" size-5 -translate-x-1.5 rounded-full"
-							alt={$WEBUI_NAME}
+							src="{WEBUI_BASE_URL}/static/gsa-logo.svg"
+							class="size-7 -translate-x-1.5"
+							alt="GSA"
 						/>
 					</div>
 					<div class=" self-center font-medium text-2xl text-gray-850 dark:text-white font-primary">


### PR DESCRIPTION
# Changelog Entry

### Description

- Per  #272, bring GSA logo back

### Screenshot
<img width="1133" alt="image" src="https://github.com/user-attachments/assets/7ff5a8b9-c609-4a26-b6ff-c21ab0559951" />


