### PR TITLE
Fixes for text contrast issues (sitewide) #365

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -303,3 +303,12 @@ input[type='number'] {
 .hljs-strong {
 	font-weight: 700;
 }
+
+.gsa-blue {
+	background-color: #005087;
+}
+
+.gsa-blue:focus,
+.gsa-blue:hover {
+	background-color: #4D84AA;
+}

--- a/src/app.css
+++ b/src/app.css
@@ -213,7 +213,7 @@ input[type='number'] {
 .ProseMirror p.is-editor-empty:first-child::before {
 	content: attr(data-placeholder);
 	float: left;
-	color: #adb5bd;
+	color: #898989;
 	pointer-events: none;
 
 	@apply line-clamp-1 absolute;

--- a/src/app.css
+++ b/src/app.css
@@ -1,3 +1,8 @@
+:root {
+	--gsa-blue: #005087;
+	--gsa-blue-hover: #4d84aa;
+}
+
 @font-face {
 	font-family: 'Inter';
 	src: url('/assets/fonts/Inter-Variable.ttf');
@@ -304,11 +309,13 @@ input[type='number'] {
 	font-weight: 700;
 }
 
-.gsa-blue {
-	background-color: #005087;
+/* GSA custom colors */
+
+.bg-gsa-blue {
+	background-color: var(--gsa-blue);
 }
 
-.gsa-blue:focus,
-.gsa-blue:hover {
-	background-color: #4d84aa;
+.bg-gsa-blue:focus,
+.bg-gsa-blue:hover {
+	background-color: var(--gsa-blue-hover);
 }

--- a/src/app.css
+++ b/src/app.css
@@ -310,5 +310,5 @@ input[type='number'] {
 
 .gsa-blue:focus,
 .gsa-blue:hover {
-	background-color: #4D84AA;
+	background-color: #4d84aa;
 }

--- a/src/lib/components/admin/Evaluations.svelte
+++ b/src/lib/components/admin/Evaluations.svelte
@@ -44,7 +44,7 @@
 				class="px-0.5 py-1 min-w-fit rounded-lg lg:flex-none flex text-right transition {selectedTab ===
 				'leaderboard'
 					? ''
-					: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+					: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 				on:click={() => {
 					selectedTab = 'leaderboard';
 				}}
@@ -70,7 +70,7 @@
 					class="px-0.5 py-1 min-w-fit rounded-lg lg:flex-none flex text-right transition {selectedTab ===
 					'feedbacks'
 						? ''
-						: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+						: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 					on:click={() => {
 						selectedTab = 'feedbacks';
 					}}

--- a/src/lib/components/admin/Evaluations/Feedbacks.svelte
+++ b/src/lib/components/admin/Evaluations/Feedbacks.svelte
@@ -112,7 +112,7 @@
 
 		<div class="flex self-center w-[1px] h-6 mx-2.5 bg-gray-50 dark:bg-gray-850" />
 
-		<span class="text-lg font-medium text-gray-500 dark:text-gray-300">{feedbacks.length}</span>
+		<span class="text-lg font-medium text-gray-600 dark:text-gray-300">{feedbacks.length}</span>
 	</div>
 
 	<div>
@@ -133,12 +133,12 @@
 
 <div class="scrollbar-hidden relative whitespace-nowrap overflow-x-auto max-w-full rounded pt-0.5">
 	{#if (feedbacks ?? []).length === 0}
-		<div class="text-center text-xs text-gray-500 dark:text-gray-400 py-1">
+		<div class="text-center text-xs text-gray-600 dark:text-gray-400 py-1">
 			{$i18n.t('No feedbacks found')}
 		</div>
 	{:else}
 		<table
-			class="w-full text-sm text-left text-gray-500 dark:text-gray-400 table-auto max-w-full rounded"
+			class="w-full text-sm text-left text-gray-600 dark:text-gray-400 table-auto max-w-full rounded"
 		>
 			<thead
 				class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-850 dark:text-gray-400 -translate-y-0.5"
@@ -249,7 +249,7 @@
 
 {#if feedbacks.length > 0}
 	<div class=" flex flex-col justify-end w-full text-right gap-1">
-		<div class="line-clamp-1 text-gray-500 text-xs">
+		<div class="line-clamp-1 text-gray-600 text-xs">
 			{$i18n.t('Help us create the best community leaderboard by sharing your feedback history!')}
 		</div>
 

--- a/src/lib/components/admin/Evaluations/Leaderboard.svelte
+++ b/src/lib/components/admin/Evaluations/Leaderboard.svelte
@@ -274,7 +274,7 @@
 
 		<div class="flex self-center w-[1px] h-6 mx-2.5 bg-gray-50 dark:bg-gray-850" />
 
-		<span class="text-lg font-medium text-gray-500 dark:text-gray-300 mr-1.5"
+		<span class="text-lg font-medium text-gray-600 dark:text-gray-300 mr-1.5"
 			>{rankedModels.length}</span
 		>
 	</div>
@@ -307,12 +307,12 @@
 		</div>
 	{/if}
 	{#if (rankedModels ?? []).length === 0}
-		<div class="text-center text-xs text-gray-500 dark:text-gray-400 py-1">
+		<div class="text-center text-xs text-gray-600 dark:text-gray-400 py-1">
 			{$i18n.t('No models found')}
 		</div>
 	{:else}
 		<table
-			class="w-full text-sm text-left text-gray-500 dark:text-gray-400 table-auto max-w-full rounded {loadingLeaderboard
+			class="w-full text-sm text-left text-gray-600 dark:text-gray-400 table-auto max-w-full rounded {loadingLeaderboard
 				? 'opacity-20'
 				: ''}"
 		>
@@ -396,7 +396,7 @@
 	{/if}
 </div>
 
-<div class=" text-gray-500 text-xs mt-1.5 w-full flex justify-end">
+<div class=" text-gray-600 text-xs mt-1.5 w-full flex justify-end">
 	<div class=" text-right">
 		<div class="line-clamp-1">
 			ⓘ {$i18n.t(

--- a/src/lib/components/admin/Functions.svelte
+++ b/src/lib/components/admin/Functions.svelte
@@ -191,7 +191,7 @@
 		<div class="flex md:self-center text-xl items-center font-medium px-0.5">
 			{$i18n.t('Functions')}
 			<div class="flex self-center w-[1px] h-6 mx-2.5 bg-gray-50 dark:bg-gray-850" />
-			<span class="text-base font-lg text-gray-500 dark:text-gray-300">{filteredItems.length}</span>
+			<span class="text-base font-lg text-gray-600 dark:text-gray-300">{filteredItems.length}</span>
 		</div>
 	</div>
 
@@ -250,7 +250,7 @@
 						</div>
 
 						<div class="flex gap-1.5 px-1">
-							<div class=" text-gray-500 text-xs font-medium flex-shrink-0">{func.id}</div>
+							<div class=" text-gray-600 text-xs font-medium flex-shrink-0">{func.id}</div>
 
 							<div class=" text-xs overflow-hidden text-ellipsis line-clamp-1">
 								{func.meta.description}
@@ -369,7 +369,7 @@
 	{/each}
 </div>
 
-<!-- <div class=" text-gray-500 text-xs mt-1 mb-2">
+<!-- <div class=" text-gray-600 text-xs mt-1 mb-2">
 	ⓘ {$i18n.t(
 		'Admins have access to all tools at all times; users need tools assigned per model in the workspace.'
 	)}
@@ -484,7 +484,7 @@
 		deleteHandler(selectedFunction);
 	}}
 >
-	<div class=" text-sm text-gray-500">
+	<div class=" text-sm text-gray-600">
 		{$i18n.t('This will delete')} <span class="  font-semibold">{selectedFunction.name}</span>.
 	</div>
 </DeleteConfirmDialog>
@@ -523,7 +523,7 @@
 		reader.readAsText(importFiles[0]);
 	}}
 >
-	<div class="text-sm text-gray-500">
+	<div class="text-sm text-gray-600">
 		<div class=" bg-yellow-500/20 text-yellow-700 dark:text-yellow-200 rounded-lg px-4 py-3">
 			<div>Please carefully review the following warnings:</div>
 

--- a/src/lib/components/admin/Functions/FunctionEditor.svelte
+++ b/src/lib/components/admin/Functions/FunctionEditor.svelte
@@ -333,7 +333,7 @@ class Pipe:
 
 					<div class=" flex gap-2 px-1 items-center">
 						{#if edit}
-							<div class="text-sm text-gray-500 flex-shrink-0">
+							<div class="text-sm text-gray-600 flex-shrink-0">
 								{id}
 							</div>
 						{:else}
@@ -384,7 +384,7 @@ class Pipe:
 
 				<div class="pb-3 flex justify-between">
 					<div class="flex-1 pr-3">
-						<div class="text-xs text-gray-500 line-clamp-2">
+						<div class="text-xs text-gray-600 line-clamp-2">
 							<span class=" font-semibold dark:text-gray-200">{$i18n.t('Warning:')}</span>
 							{$i18n.t('Functions allow arbitrary code execution')} <br />—
 							<span class=" font-medium dark:text-gray-400"
@@ -411,7 +411,7 @@ class Pipe:
 		submitHandler();
 	}}
 >
-	<div class="text-sm text-gray-500">
+	<div class="text-sm text-gray-600">
 		<div class=" bg-yellow-500/20 text-yellow-700 dark:text-yellow-200 rounded-lg px-4 py-3">
 			<div>{$i18n.t('Please carefully review the following warnings:')}</div>
 

--- a/src/lib/components/admin/Settings.svelte
+++ b/src/lib/components/admin/Settings.svelte
@@ -47,7 +47,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 lg:flex-none flex text-right transition {selectedTab ===
 			'general'
 				? ''
-				: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'general';
 			}}
@@ -73,7 +73,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-right transition {selectedTab ===
 			'connections'
 				? ''
-				: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'connections';
 			}}
@@ -97,7 +97,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-right transition {selectedTab ===
 			'models'
 				? ''
-				: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'models';
 			}}
@@ -123,7 +123,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-right transition {selectedTab ===
 			'evaluations'
 				? ''
-				: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'evaluations';
 			}}
@@ -138,7 +138,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-right transition {selectedTab ===
 			'documents'
 				? ''
-				: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'documents';
 			}}
@@ -168,7 +168,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-right transition {selectedTab ===
 			'web'
 				? ''
-				: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'web';
 			}}
@@ -192,7 +192,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-right transition {selectedTab ===
 			'interface'
 				? ''
-				: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'interface';
 			}}
@@ -218,7 +218,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-right transition {selectedTab ===
 			'audio'
 				? ''
-				: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'audio';
 			}}
@@ -245,7 +245,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-right transition {selectedTab ===
 			'images'
 				? ''
-				: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'images';
 			}}
@@ -271,7 +271,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-right transition {selectedTab ===
 			'pipelines'
 				? ''
-				: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'pipelines';
 			}}
@@ -301,7 +301,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-right transition {selectedTab ===
 			'db'
 				? ''
-				: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'db';
 			}}

--- a/src/lib/components/admin/Settings/Connections.svelte
+++ b/src/lib/components/admin/Settings/Connections.svelte
@@ -317,7 +317,7 @@
 						<div class="mt-1 text-xs text-gray-400 dark:text-gray-500">
 							{$i18n.t('Trouble accessing Ollama?')}
 							<a
-								class=" text-gray-300 font-medium underline"
+								class=" text-gray-600 font-medium underline"
 								href="https://github.com/open-webui/open-webui#troubleshooting"
 								target="_blank"
 							>

--- a/src/lib/components/admin/Settings/Connections/AddConnectionModal.svelte
+++ b/src/lib/components/admin/Settings/Connections/AddConnectionModal.svelte
@@ -146,7 +146,7 @@
 					<div class="px-1">
 						<div class="flex gap-2">
 							<div class="flex flex-col w-full">
-								<div class=" mb-0.5 text-xs text-gray-500">{$i18n.t('URL')}</div>
+								<div class=" mb-0.5 text-xs text-gray-600">{$i18n.t('URL')}</div>
 
 								<div class="flex-1">
 									<input
@@ -192,7 +192,7 @@
 
 						<div class="flex gap-2 mt-2">
 							<div class="flex flex-col w-full">
-								<div class=" mb-0.5 text-xs text-gray-500">{$i18n.t('Key')}</div>
+								<div class=" mb-0.5 text-xs text-gray-600">{$i18n.t('Key')}</div>
 
 								<div class="flex-1">
 									<SensitiveInput
@@ -205,7 +205,7 @@
 							</div>
 
 							<div class="flex flex-col w-full">
-								<div class=" mb-1 text-xs text-gray-500">{$i18n.t('Prefix ID')}</div>
+								<div class=" mb-1 text-xs text-gray-600">{$i18n.t('Prefix ID')}</div>
 
 								<div class="flex-1">
 									<Tooltip
@@ -229,7 +229,7 @@
 
 						<div class="flex flex-col w-full">
 							<div class="mb-1 flex justify-between">
-								<div class="text-xs text-gray-500">{$i18n.t('Model IDs')}</div>
+								<div class="text-xs text-gray-600">{$i18n.t('Model IDs')}</div>
 							</div>
 
 							{#if modelIds.length > 0}
@@ -253,7 +253,7 @@
 									{/each}
 								</div>
 							{:else}
-								<div class="text-gray-500 text-xs text-center py-2 px-10">
+								<div class="text-gray-600 text-xs text-center py-2 px-10">
 									{#if ollama}
 										{$i18n.t('Leave empty to include all models from "{{URL}}/api/tags" endpoint', {
 											URL: url
@@ -273,7 +273,7 @@
 							<input
 								class="w-full py-1 text-sm rounded-lg bg-transparent {modelId
 									? ''
-									: 'text-gray-500'} placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-none"
+									: 'text-gray-600'} placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-none"
 								bind:value={modelId}
 								placeholder={$i18n.t('Add a model ID')}
 							/>

--- a/src/lib/components/admin/Settings/Connections/ManageOllamaModal.svelte
+++ b/src/lib/components/admin/Settings/Connections/ManageOllamaModal.svelte
@@ -648,7 +648,7 @@
 								<div class="mt-2 mb-1 text-xs text-gray-400 dark:text-gray-500">
 									{$i18n.t('To access the available model names for downloading,')}
 									<a
-										class=" text-gray-500 dark:text-gray-300 font-medium underline"
+										class=" text-gray-600 dark:text-gray-300 font-medium underline"
 										href="https://ollama.com/library"
 										target="_blank">{$i18n.t('click here.')}</a
 									>
@@ -831,7 +831,7 @@
 								<div class="flex justify-between items-center text-xs">
 									<div class=" text-sm font-medium">{$i18n.t('Experimental')}</div>
 									<button
-										class=" text-xs font-medium text-gray-500"
+										class=" text-xs font-medium text-gray-600"
 										type="button"
 										on:click={() => {
 											showExperimentalOllama = !showExperimentalOllama;
@@ -989,7 +989,7 @@
 									<div class=" mt-1 text-xs text-gray-400 dark:text-gray-500">
 										{$i18n.t('To access the GGUF models available for downloading,')}
 										<a
-											class=" text-gray-500 dark:text-gray-300 font-medium underline"
+											class=" text-gray-600 dark:text-gray-300 font-medium underline"
 											href="https://huggingface.co/models?search=gguf"
 											target="_blank">{$i18n.t('click here.')}</a
 										>

--- a/src/lib/components/admin/Settings/Evaluations.svelte
+++ b/src/lib/components/admin/Settings/Evaluations.svelte
@@ -130,7 +130,7 @@
 								/>
 							{/each}
 						{:else}
-							<div class=" text-center text-xs text-gray-500">
+							<div class=" text-center text-xs text-gray-600">
 								{$i18n.t(
 									`Using the default arena model with all models. Click the plus button to add custom models.`
 								)}

--- a/src/lib/components/admin/Settings/Evaluations/ArenaModelModal.svelte
+++ b/src/lib/components/admin/Settings/Evaluations/ArenaModelModal.svelte
@@ -226,7 +226,7 @@
 						</div>
 						<div class="flex gap-2">
 							<div class="flex flex-col w-full">
-								<div class=" mb-0.5 text-xs text-gray-500">{$i18n.t('Name')}</div>
+								<div class=" mb-0.5 text-xs text-gray-600">{$i18n.t('Name')}</div>
 
 								<div class="flex-1">
 									<input
@@ -241,7 +241,7 @@
 							</div>
 
 							<div class="flex flex-col w-full">
-								<div class=" mb-0.5 text-xs text-gray-500">{$i18n.t('ID')}</div>
+								<div class=" mb-0.5 text-xs text-gray-600">{$i18n.t('ID')}</div>
 
 								<div class="flex-1">
 									<input
@@ -258,7 +258,7 @@
 						</div>
 
 						<div class="flex flex-col w-full mt-2">
-							<div class=" mb-1 text-xs text-gray-500">{$i18n.t('Description')}</div>
+							<div class=" mb-1 text-xs text-gray-600">{$i18n.t('Description')}</div>
 
 							<div class="flex-1">
 								<input
@@ -283,11 +283,11 @@
 
 						<div class="flex flex-col w-full">
 							<div class="mb-1 flex justify-between">
-								<div class="text-xs text-gray-500">{$i18n.t('Models')}</div>
+								<div class="text-xs text-gray-600">{$i18n.t('Models')}</div>
 
 								<div>
 									<button
-										class=" text-xs text-gray-500"
+										class=" text-xs text-gray-600"
 										type="button"
 										on:click={() => {
 											filterMode = filterMode === 'include' ? 'exclude' : 'include';
@@ -323,7 +323,7 @@
 									{/each}
 								</div>
 							{:else}
-								<div class="text-gray-500 text-xs text-center py-2">
+								<div class="text-gray-600 text-xs text-center py-2">
 									{$i18n.t('Leave empty to include all models or select specific models')}
 								</div>
 							{/if}
@@ -335,7 +335,7 @@
 							<select
 								class="w-full py-1 text-sm rounded-lg bg-transparent {selectedModelId
 									? ''
-									: 'text-gray-500'} placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-none"
+									: 'text-gray-600'} placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-none"
 								bind:value={selectedModelId}
 							>
 								<option value="">{$i18n.t('Select a model')}</option>

--- a/src/lib/components/admin/Settings/Evaluations/Model.svelte
+++ b/src/lib/components/admin/Settings/Evaluations/Model.svelte
@@ -40,7 +40,7 @@
 					</div>
 
 					<div class="flex items-center gap-1">
-						<div class=" text-xs w-full text-gray-500 bg-transparent line-clamp-1">
+						<div class=" text-xs w-full text-gray-600 bg-transparent line-clamp-1">
 							{model?.meta?.description ?? model.id}
 						</div>
 					</div>

--- a/src/lib/components/admin/Settings/General.svelte
+++ b/src/lib/components/admin/Settings/General.svelte
@@ -145,7 +145,7 @@
 								<a
 									href="https://docs.openwebui.com/getting-started/advanced-topics/api-endpoints"
 									target="_blank"
-									class=" text-gray-300 font-medium underline"
+									class=" text-gray-600 font-medium underline"
 								>
 									{$i18n.t('To learn more about available endpoints, visit our documentation.')}
 								</a>
@@ -217,7 +217,7 @@
 
 					<div class="mt-2 text-xs text-gray-400 dark:text-gray-500">
 						{$i18n.t('Valid time units:')}
-						<span class=" text-gray-300 font-medium"
+						<span class=" text-gray-600 font-medium"
 							>{$i18n.t("'s', 'm', 'h', 'd', 'w' or '-1' for no expiration.")}</span
 						>
 					</div>
@@ -391,7 +391,7 @@
 						</div>
 						<div class="text-xs text-gray-400 dark:text-gray-500">
 							<a
-								class=" text-gray-300 font-medium underline"
+								class=" text-gray-600 font-medium underline"
 								href="https://ldap.com/ldap-filters/"
 								target="_blank"
 							>

--- a/src/lib/components/admin/Settings/Images.svelte
+++ b/src/lib/components/admin/Settings/Images.svelte
@@ -336,7 +336,7 @@
 						<div class="mt-2 text-xs text-gray-400 dark:text-gray-500">
 							{$i18n.t('Include `--api` flag when running stable-diffusion-webui')}
 							<a
-								class=" text-gray-300 font-medium"
+								class=" text-gray-600 font-medium"
 								href="https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/3734"
 								target="_blank"
 							>
@@ -358,7 +358,7 @@
 						<div class="mt-2 text-xs text-gray-400 dark:text-gray-500">
 							{$i18n.t('Include `--api-auth` flag when running stable-diffusion-webui')}
 							<a
-								class=" text-gray-300 font-medium"
+								class=" text-gray-600 font-medium"
 								href="https://github.com/AUTOMATIC1111/stable-diffusion-webui/discussions/13993"
 								target="_blank"
 							>

--- a/src/lib/components/admin/Settings/Models.svelte
+++ b/src/lib/components/admin/Settings/Models.svelte
@@ -146,7 +146,7 @@
 				<div class="flex items-center md:self-center text-xl font-medium px-0.5">
 					{$i18n.t('Models')}
 					<div class="flex self-center w-[1px] h-6 mx-2.5 bg-gray-50 dark:bg-gray-850" />
-					<span class="text-lg font-medium text-gray-500 dark:text-gray-300"
+					<span class="text-lg font-medium text-gray-600 dark:text-gray-300"
 						>{filteredModels.length}</span
 					>
 				</div>
@@ -208,7 +208,7 @@
 								</div>
 							</div>
 
-							<div class=" flex-1 self-center {(model?.is_active ?? true) ? '' : 'text-gray-500'}">
+							<div class=" flex-1 self-center {(model?.is_active ?? true) ? '' : 'text-gray-600'}">
 								<Tooltip
 									content={marked.parse(
 										!!model?.meta?.description
@@ -222,7 +222,7 @@
 								>
 									<div class="  font-semibold line-clamp-1">{model.name}</div>
 								</Tooltip>
-								<div class=" text-xs overflow-hidden text-ellipsis line-clamp-1 text-gray-500">
+								<div class=" text-xs overflow-hidden text-ellipsis line-clamp-1 text-gray-600">
 									<span class=" line-clamp-1">
 										{!!model?.meta?.description
 											? model?.meta?.description
@@ -274,7 +274,7 @@
 				{/each}
 			{:else}
 				<div class="flex flex-col items-center justify-center w-full h-20">
-					<div class="text-gray-500 dark:text-gray-400 text-xs">
+					<div class="text-gray-600 dark:text-gray-400 text-xs">
 						{$i18n.t('No models found')}
 					</div>
 				</div>

--- a/src/lib/components/admin/Settings/Models/ConfigureModelsModal.svelte
+++ b/src/lib/components/admin/Settings/Models/ConfigureModelsModal.svelte
@@ -130,7 +130,7 @@
 						<div>
 							<div class="flex flex-col w-full">
 								<div class="mb-1 flex justify-between">
-									<div class="text-xs text-gray-500">{$i18n.t('Reorder Models')}</div>
+									<div class="text-xs text-gray-600">{$i18n.t('Reorder Models')}</div>
 								</div>
 
 								<ModelList bind:modelIds />
@@ -142,7 +142,7 @@
 						<div>
 							<div class="flex flex-col w-full">
 								<div class="mb-1 flex justify-between">
-									<div class="text-xs text-gray-500">{$i18n.t('Default Models')}</div>
+									<div class="text-xs text-gray-600">{$i18n.t('Default Models')}</div>
 								</div>
 
 								{#if defaultModelIds.length > 0}
@@ -168,7 +168,7 @@
 										{/each}
 									</div>
 								{:else}
-									<div class="text-gray-500 text-xs text-center py-2">
+									<div class="text-gray-600 text-xs text-center py-2">
 										{$i18n.t('No models selected')}
 									</div>
 								{/if}
@@ -179,7 +179,7 @@
 									<select
 										class="w-full py-1 text-sm rounded-lg bg-transparent {selectedModelId
 											? ''
-											: 'text-gray-500'} placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-none"
+											: 'text-gray-600'} placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-none"
 										bind:value={selectedModelId}
 									>
 										<option value="">{$i18n.t('Select a model')}</option>

--- a/src/lib/components/admin/Settings/Models/ModelList.svelte
+++ b/src/lib/components/admin/Settings/Models/ModelList.svelte
@@ -52,7 +52,7 @@
 		{/each}
 	</div>
 {:else}
-	<div class="text-gray-500 text-xs text-center py-2">
+	<div class="text-gray-600 text-xs text-center py-2">
 		{$i18n.t('No models found')}
 	</div>
 {/if}

--- a/src/lib/components/admin/Settings/Pipelines.svelte
+++ b/src/lib/components/admin/Settings/Pipelines.svelte
@@ -389,7 +389,7 @@
 						</button>
 					</div>
 
-					<div class="mt-2 text-xs text-gray-500">
+					<div class="mt-2 text-xs text-gray-600">
 						<span class=" font-semibold dark:text-gray-200">Warning:</span> Pipelines are a plugin
 						system with arbitrary code execution —
 						<span class=" font-medium dark:text-gray-400"
@@ -493,7 +493,7 @@
 																</select>
 															{:else if (valves_spec.properties[property]?.type ?? null) === 'boolean'}
 																<div class="flex justify-between items-center">
-																	<div class="text-xs text-gray-500">
+																	<div class="text-xs text-gray-600">
 																		{valves[property] ? 'Enabled' : 'Disabled'}
 																	</div>
 

--- a/src/lib/components/admin/Users.svelte
+++ b/src/lib/components/admin/Users.svelte
@@ -55,7 +55,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg lg:flex-none flex text-right transition {selectedTab ===
 			'overview'
 				? ''
-				: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'overview';
 			}}
@@ -79,7 +79,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg lg:flex-none flex text-right transition {selectedTab ===
 			'groups'
 				? ''
-				: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'groups';
 			}}

--- a/src/lib/components/admin/Users/Groups.svelte
+++ b/src/lib/components/admin/Users/Groups.svelte
@@ -113,7 +113,7 @@
 			{$i18n.t('Groups')}
 			<div class="flex self-center w-[1px] h-6 mx-2.5 bg-gray-50 dark:bg-gray-850" />
 
-			<span class="text-lg font-medium text-gray-500 dark:text-gray-300">{groups.length}</span>
+			<span class="text-lg font-medium text-gray-600 dark:text-gray-300">{groups.length}</span>
 		</div>
 
 		<div class="flex gap-1">

--- a/src/lib/components/admin/Users/Groups/Display.svelte
+++ b/src/lib/components/admin/Users/Groups/Display.svelte
@@ -12,7 +12,7 @@
 
 <div class="flex gap-2">
 	<div class="flex flex-col w-full">
-		<div class=" mb-0.5 text-xs text-gray-500">{$i18n.t('Name')}</div>
+		<div class=" mb-0.5 text-xs text-gray-600">{$i18n.t('Name')}</div>
 
 		<div class="flex-1">
 			<input
@@ -28,12 +28,12 @@
 </div>
 
 <!-- <div class="flex flex-col w-full mt-2">
-	<div class=" mb-1 text-xs text-gray-500">{$i18n.t('Color')}</div>
+	<div class=" mb-1 text-xs text-gray-600">{$i18n.t('Color')}</div>
 
 	<div class="flex-1">
 		<Tooltip content={$i18n.t('Hex Color - Leave empty for default color')} placement="top-start">
 			<div class="flex gap-0.5">
-				<div class="text-gray-500">#</div>
+				<div class="text-gray-600">#</div>
 
 				<input
 					class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-none"
@@ -48,7 +48,7 @@
 </div> -->
 
 <div class="flex flex-col w-full mt-2">
-	<div class=" mb-1 text-xs text-gray-500">{$i18n.t('Description')}</div>
+	<div class=" mb-1 text-xs text-gray-600">{$i18n.t('Description')}</div>
 
 	<div class="flex-1">
 		<Textarea

--- a/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
@@ -131,7 +131,7 @@
 									class="px-0.5 py-1 max-w-fit w-fit rounded-lg flex-1 lg:flex-none flex text-right transition {selectedTab ===
 									'general'
 										? ''
-										: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+										: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 									on:click={() => {
 										selectedTab = 'general';
 									}}
@@ -160,7 +160,7 @@
 									class="px-0.5 py-1 max-w-fit w-fit rounded-lg flex-1 lg:flex-none flex text-right transition {selectedTab ===
 									'permissions'
 										? ''
-										: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+										: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 									on:click={() => {
 										selectedTab = 'permissions';
 									}}
@@ -178,7 +178,7 @@
 									class="px-0.5 py-1 max-w-fit w-fit rounded-lg flex-1 lg:flex-none flex text-right transition {selectedTab ===
 									'users'
 										? ''
-										: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+										: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 									on:click={() => {
 										selectedTab = 'users';
 									}}
@@ -213,7 +213,7 @@
 								class="px-0.5 pb-1.5 min-w-fit flex text-right transition border-b-2 {selectedTab ===
 								'display'
 									? ' dark:border-white'
-									: 'border-transparent text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									: 'border-transparent text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 								on:click={() => {
 									selectedTab = 'display';
 								}}
@@ -228,7 +228,7 @@
 								class="px-0.5 pb-1.5 min-w-fit flex text-right transition border-b-2 {selectedTab ===
 								'permissions'
 									? '  dark:border-white'
-									: 'border-transparent text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									: 'border-transparent text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 								on:click={() => {
 									selectedTab = 'permissions';
 								}}
@@ -243,7 +243,7 @@
 								class="px-0.5 pb-1.5 min-w-fit flex text-right transition border-b-2 {selectedTab ===
 								'users'
 									? ' dark:border-white'
-									: ' border-transparent text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									: ' border-transparent text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 								on:click={() => {
 									selectedTab = 'users';
 								}}

--- a/src/lib/components/admin/Users/Groups/Permissions.svelte
+++ b/src/lib/components/admin/Users/Groups/Permissions.svelte
@@ -38,7 +38,7 @@
 				<div class=" space-y-1.5">
 					<div class="flex flex-col w-full">
 						<div class="mb-1 flex justify-between">
-							<div class="text-xs text-gray-500">{$i18n.t('Model IDs')}</div>
+							<div class="text-xs text-gray-600">{$i18n.t('Model IDs')}</div>
 						</div>
 
 						{#if model_ids.length > 0}
@@ -62,7 +62,7 @@
 								{/each}
 							</div>
 						{:else}
-							<div class="text-gray-500 text-xs text-center py-2 px-10">
+							<div class="text-gray-600 text-xs text-center py-2 px-10">
 								{$i18n.t('No model IDs')}
 							</div>
 						{/if}
@@ -74,7 +74,7 @@
 					<select
 						class="w-full py-1 text-sm rounded-lg bg-transparent {selectedModelId
 							? ''
-							: 'text-gray-500'} placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-none"
+							: 'text-gray-600'} placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-none"
 						bind:value={selectedModelId}
 					>
 						<option value="">{$i18n.t('Select a model')}</option>

--- a/src/lib/components/admin/Users/Groups/Users.svelte
+++ b/src/lib/components/admin/Users/Groups/Users.svelte
@@ -123,7 +123,7 @@
 					</div>
 				{/each}
 			{:else}
-				<div class="text-gray-500 text-xs text-center py-2 px-10">
+				<div class="text-gray-600 text-xs text-center py-2 px-10">
 					{$i18n.t('No users were found.')}
 				</div>
 			{/if}

--- a/src/lib/components/admin/Users/UserList.svelte
+++ b/src/lib/components/admin/Users/UserList.svelte
@@ -129,7 +129,7 @@
 		{$i18n.t('Users')}
 		<div class="flex self-center w-[1px] h-6 mx-2.5 bg-gray-50 dark:bg-gray-850" />
 
-		<span class="text-lg font-medium text-gray-500 dark:text-gray-300">{users.length}</span>
+		<span class="text-lg font-medium text-gray-600 dark:text-gray-300">{users.length}</span>
 	</div>
 
 	<div class="flex gap-1">
@@ -175,7 +175,7 @@
 
 <div class="scrollbar-hidden relative whitespace-nowrap overflow-x-auto max-w-full rounded pt-0.5">
 	<table
-		class="w-full text-sm text-left text-gray-500 dark:text-gray-400 table-auto max-w-full rounded"
+		class="w-full text-sm text-left text-gray-600 dark:text-gray-400 table-auto max-w-full rounded"
 	>
 		<thead
 			class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-850 dark:text-gray-400 -translate-y-0.5"
@@ -448,7 +448,7 @@
 	</table>
 </div>
 
-<div class=" text-gray-500 text-xs mt-1.5 text-right">
+<div class=" text-gray-600 text-xs mt-1.5 text-right">
 	ⓘ {$i18n.t("Click on the user role button to change a user's role.")}
 </div>
 

--- a/src/lib/components/admin/Users/UserList/EditUserModal.svelte
+++ b/src/lib/components/admin/Users/UserList/EditUserModal.svelte
@@ -70,7 +70,7 @@
 						<div>
 							<div class=" self-center capitalize font-semibold">{selectedUser.name}</div>
 
-							<div class="text-xs text-gray-500">
+							<div class="text-xs text-gray-600">
 								{$i18n.t('Created at')}
 								{dayjs(selectedUser.created_at * 1000).format($i18n.t('MMMM DD, YYYY'))}
 							</div>
@@ -81,7 +81,7 @@
 
 					<div class=" flex flex-col space-y-1.5">
 						<div class="flex flex-col w-full">
-							<div class=" mb-1 text-xs text-gray-500">{$i18n.t('Email')}</div>
+							<div class=" mb-1 text-xs text-gray-600">{$i18n.t('Email')}</div>
 
 							<div class="flex-1">
 								<input
@@ -96,7 +96,7 @@
 						</div>
 
 						<div class="flex flex-col w-full">
-							<div class=" mb-1 text-xs text-gray-500">{$i18n.t('Name')}</div>
+							<div class=" mb-1 text-xs text-gray-600">{$i18n.t('Name')}</div>
 
 							<div class="flex-1">
 								<input
@@ -110,7 +110,7 @@
 						</div>
 
 						<div class="flex flex-col w-full">
-							<div class=" mb-1 text-xs text-gray-500">{$i18n.t('New Password')}</div>
+							<div class=" mb-1 text-xs text-gray-600">{$i18n.t('New Password')}</div>
 
 							<div class="flex-1">
 								<input

--- a/src/lib/components/channel/Messages.svelte
+++ b/src/lib/components/channel/Messages.svelte
@@ -72,7 +72,7 @@
 					<div class="flex flex-col gap-1.5 pb-5 pt-10">
 						<div class="text-2xl font-medium capitalize">{channel.name}</div>
 
-						<div class=" text-gray-500">
+						<div class=" text-gray-600">
 							This channel was created on {dayjs(channel.created_at / 1000000).format(
 								'MMMM D, YYYY'
 							)}. This is the very beginning of the {channel.name}

--- a/src/lib/components/channel/Messages/Message.svelte
+++ b/src/lib/components/channel/Messages/Message.svelte
@@ -163,7 +163,7 @@
 
 					{#if message.created_at}
 						<div
-							class="mt-1.5 flex flex-shrink-0 items-center text-xs self-center invisible group-hover:visible text-gray-500 font-medium first-letter:capitalize"
+							class="mt-1.5 flex flex-shrink-0 items-center text-xs self-center invisible group-hover:visible text-gray-600 font-medium first-letter:capitalize"
 						>
 							<Tooltip
 								content={dayjs(message.created_at / 1000000).format('dddd, DD MMMM YYYY HH:mm')}
@@ -267,7 +267,7 @@
 						<Markdown
 							id={message.id}
 							content={message.content}
-						/>{#if message.created_at !== message.updated_at}<span class="text-gray-500 text-[10px]"
+						/>{#if message.created_at !== message.updated_at}<span class="text-gray-600 text-[10px]"
 								>(edited)</span
 							>{/if}
 					</div>
@@ -303,7 +303,7 @@
 											{/if}
 
 											{#if reaction.user_ids.length > 0}
-												<div class="text-xs font-medium text-gray-500 dark:text-gray-400">
+												<div class="text-xs font-medium text-gray-600 dark:text-gray-400">
 													{reaction.user_ids?.length}
 												</div>
 											{/if}
@@ -318,7 +318,7 @@
 								>
 									<Tooltip content={$i18n.t('Add Reaction')}>
 										<div
-											class="flex items-center gap-1.5 bg-gray-500/10 hover:outline hover:outline-gray-700/30 dark:hover:outline-gray-300/30 hover:outline-1 transition rounded-xl px-1 py-1 cursor-pointer text-gray-500 dark:text-gray-400"
+											class="flex items-center gap-1.5 bg-gray-500/10 hover:outline hover:outline-gray-700/30 dark:hover:outline-gray-300/30 hover:outline-1 transition rounded-xl px-1 py-1 cursor-pointer text-gray-600 dark:text-gray-400"
 										>
 											<FaceSmile />
 										</div>
@@ -331,7 +331,7 @@
 					{#if !thread && message.reply_count > 0}
 						<div class="flex items-center gap-1.5 -mt-0.5 mb-1.5">
 							<button
-								class="flex items-center text-xs py-1 text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition"
+								class="flex items-center text-xs py-1 text-gray-600 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-300 transition"
 								on:click={() => {
 									onThread(message.id);
 								}}

--- a/src/lib/components/channel/Messages/Message/ReactionPicker.svelte
+++ b/src/lib/components/channel/Messages/Message/ReactionPicker.svelte
@@ -124,14 +124,14 @@
 		<!-- Virtualized Emoji List -->
 		<div class="w-full flex justify-start h-96 overflow-y-auto px-3 pb-3 text-sm">
 			{#if emojiRows.length === 0}
-				<div class="text-center text-xs text-gray-500 dark:text-gray-400">No results</div>
+				<div class="text-center text-xs text-gray-600 dark:text-gray-400">No results</div>
 			{:else}
 				<div class="w-full flex ml-2">
 					<VirtualList rowHeight={ROW_HEIGHT} items={emojiRows} height={384} let:item>
 						<div class="w-full">
 							{#if item.length === 1 && item[0].type === 'group'}
 								<!-- Render group header -->
-								<div class="text-xs font-medium mb-2 text-gray-500 dark:text-gray-400">
+								<div class="text-xs font-medium mb-2 text-gray-600 dark:text-gray-400">
 									{item[0].label}
 								</div>
 							{:else}

--- a/src/lib/components/channel/Thread.svelte
+++ b/src/lib/components/channel/Thread.svelte
@@ -162,7 +162,7 @@
 
 			<div>
 				<button
-					class="text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300 p-2"
+					class="text-gray-600 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-300 p-2"
 					on:click={() => {
 						onClose();
 					}}

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2069,7 +2069,7 @@
 					{/if}
 					{#if $config?.features?.enable_disclaimer}
 						<div
-							class="absolute bottom-1.5 text-xs text-gray-500 text-center line-clamp-1 right-14 left-3"
+							class="absolute bottom-1.5 text-xs text-gray-600 text-center line-clamp-1 right-14 left-3"
 						>
 							{$i18n.t('GSA Chat can make mistakes. Review all responses for accuracy.')}
 						</div>

--- a/src/lib/components/chat/ChatPlaceholder.svelte
+++ b/src/lib/components/chat/ChatPlaceholder.svelte
@@ -71,7 +71,7 @@
 				className="w-fit"
 				placement="top-start"
 			>
-				<div class="flex items-center gap-2 text-gray-500 font-medium text-lg my-2 w-fit">
+				<div class="flex items-center gap-2 text-gray-600 font-medium text-lg my-2 w-fit">
 					<EyeSlash strokeWidth="2.5" className="size-5" /> Temporary Chat
 				</div>
 			</Tooltip>
@@ -92,7 +92,7 @@
 				<div in:fade={{ duration: 200, delay: 200 }}>
 					{#if models[selectedModelIdx]?.info?.meta?.description ?? null}
 						<div
-							class="mt-0.5 text-base font-normal text-gray-500 dark:text-gray-400 line-clamp-3 markdown"
+							class="mt-0.5 text-base font-normal text-gray-600 dark:text-gray-400 line-clamp-3 markdown"
 						>
 							{@html marked.parse(
 								sanitizeResponseContent(models[selectedModelIdx]?.info?.meta?.description)

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1184,7 +1184,7 @@
 														<button
 															id="send-message-button"
 															class="{prompt !== ''
-																? 'gsa-blue text-white dark:bg-white dark:text-black outline-none '
+																? 'bg-gsa-blue text-white dark:bg-white dark:text-black outline-none '
 																: 'text-white bg-gray-200 dark:text-gray-900 dark:bg-gray-700 disabled'} transition rounded-full p-1.5 self-center"
 															type="submit"
 															disabled={prompt === ''}

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -539,7 +539,7 @@
 							}}
 						>
 							<div
-								class="flex-1 flex flex-col relative w-full rounded-3xl px-1 bg-gray-600/5 dark:bg-gray-400/5 dark:text-gray-100"
+								class="flex-1 flex flex-col border border-gray-400 relative w-full rounded-3xl px-1 bg-gray-600/5 dark:bg-gray-400/5 dark:text-gray-100"
 								dir={$settings?.chatDirection ?? 'LTR'}
 							>
 								{#if files.length > 0}
@@ -1184,7 +1184,7 @@
 														<button
 															id="send-message-button"
 															class="{prompt !== ''
-																? 'bg-black text-white hover:bg-gray-900 dark:bg-white dark:text-black dark:hover:bg-gray-100 '
+																? 'bg-black text-white hover:bg-blue-700 focus:bg-blue-700 dark:bg-white dark:text-black dark:hover:bg-gray-100 '
 																: 'text-white bg-gray-200 dark:text-gray-900 dark:bg-gray-700 disabled'} transition rounded-full p-1.5 self-center"
 															type="submit"
 															disabled={prompt === ''}
@@ -1194,6 +1194,8 @@
 																viewBox="0 0 16 16"
 																fill="currentColor"
 																class="size-6"
+																role="img"
+																aria-label="send message"
 															>
 																<path
 																	fill-rule="evenodd"

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1184,7 +1184,7 @@
 														<button
 															id="send-message-button"
 															class="{prompt !== ''
-																? 'bg-black text-white hover:bg-blue-700 focus:bg-blue-700 dark:bg-white dark:text-black dark:hover:bg-gray-100 '
+																? 'gsa-blue text-white dark:bg-white dark:text-black outline-none '
 																: 'text-white bg-gray-200 dark:text-gray-900 dark:bg-gray-700 disabled'} transition rounded-full p-1.5 self-center"
 															type="submit"
 															disabled={prompt === ''}

--- a/src/lib/components/chat/MessageInput/Commands/Knowledge.svelte
+++ b/src/lib/components/chat/MessageInput/Commands/Knowledge.svelte
@@ -256,7 +256,7 @@
 										</button>
 									{/each}
 								{:else}
-									<div class=" text-gray-500 text-xs mt-1 mb-2">
+									<div class=" text-gray-600 text-xs mt-1 mb-2">
 										{$i18n.t('No files found.')}
 									</div>
 								{/if}

--- a/src/lib/components/chat/MessageInput/VoiceRecording.svelte
+++ b/src/lib/components/chat/MessageInput/VoiceRecording.svelte
@@ -376,7 +376,7 @@
 				class="text-sm
         
         
-        {loading ? ' text-gray-500  dark:text-gray-400  ' : ' text-indigo-400 '} 
+        {loading ? ' text-gray-600  dark:text-gray-400  ' : ' text-indigo-400 '} 
        font-medium flex-1 mx-auto text-center"
 			>
 				{formatSeconds(durationSeconds)}
@@ -385,7 +385,7 @@
 
 		<div class="flex items-center">
 			{#if loading}
-				<div class=" text-gray-500 rounded-full cursor-not-allowed">
+				<div class=" text-gray-600 rounded-full cursor-not-allowed">
 					<svg
 						width="24"
 						height="24"

--- a/src/lib/components/chat/Messages/Citations.svelte
+++ b/src/lib/components/chat/Messages/Citations.svelte
@@ -123,7 +123,7 @@
 		{:else}
 			<Collapsible bind:open={isCollapsibleOpen} className="w-full">
 				<div
-					class="flex items-center gap-2 text-gray-500 hover:text-gray-600 dark:hover:text-gray-400 transition cursor-pointer"
+					class="flex items-center gap-2 text-gray-600 hover:text-gray-600 dark:hover:text-gray-400 transition cursor-pointer"
 				>
 					<div class="flex-grow flex items-center gap-1 overflow-hidden">
 						<span class="whitespace-nowrap hidden sm:inline">{$i18n.t('References from')}</span>

--- a/src/lib/components/chat/Messages/CitationsModal.svelte
+++ b/src/lib/components/chat/Messages/CitationsModal.svelte
@@ -86,7 +86,7 @@
 										{document?.metadata?.name ?? document.source.name}
 									</a>
 									{#if document?.metadata?.page}
-										<span class="text-xs text-gray-500 dark:text-gray-400">
+										<span class="text-xs text-gray-600 dark:text-gray-400">
 											({$i18n.t('page')}
 											{document.metadata.page + 1})
 										</span>
@@ -110,11 +110,11 @@
 												<span class={`px-1 rounded font-medium ${getRelevanceColor(percentage)}`}>
 													{percentage.toFixed(2)}%
 												</span>
-												<span class="text-gray-500 dark:text-gray-500">
+												<span class="text-gray-600 dark:text-gray-500">
 													({document.distance.toFixed(4)})
 												</span>
 											{:else}
-												<span class="text-gray-500 dark:text-gray-500">
+												<span class="text-gray-600 dark:text-gray-500">
 													{document.distance.toFixed(4)}
 												</span>
 											{/if}

--- a/src/lib/components/chat/Messages/CodeBlock.svelte
+++ b/src/lib/components/chat/Messages/CodeBlock.svelte
@@ -381,12 +381,12 @@ __builtins__.input = input`);
 
 			{#if executing}
 				<div class="bg-[#202123] text-white px-4 py-4 rounded-b-lg">
-					<div class=" text-gray-500 text-xs mb-1">STDOUT/STDERR</div>
+					<div class=" text-gray-600 text-xs mb-1">STDOUT/STDERR</div>
 					<div class="text-sm">Running...</div>
 				</div>
 			{:else if stdout || stderr || result}
 				<div class="bg-[#202123] text-white px-4 py-4 rounded-b-lg">
-					<div class=" text-gray-500 text-xs mb-1">STDOUT/STDERR</div>
+					<div class=" text-gray-600 text-xs mb-1">STDOUT/STDERR</div>
 					<div class="text-sm">{stdout || stderr || result}</div>
 				</div>
 			{/if}

--- a/src/lib/components/chat/Messages/CodeExecutionModal.svelte
+++ b/src/lib/components/chat/Messages/CodeExecutionModal.svelte
@@ -69,13 +69,13 @@
 					<div class="dark:bg-[#202123] dark:text-white px-4 py-4 rounded-b-lg flex flex-col gap-3">
 						{#if codeExecution?.result?.error}
 							<div>
-								<div class=" text-gray-500 text-xs mb-1">{$i18n.t('ERROR')}</div>
+								<div class=" text-gray-600 text-xs mb-1">{$i18n.t('ERROR')}</div>
 								<div class="text-sm">{codeExecution?.result?.error}</div>
 							</div>
 						{/if}
 						{#if codeExecution?.result?.output}
 							<div>
-								<div class=" text-gray-500 text-xs mb-1">{$i18n.t('OUTPUT')}</div>
+								<div class=" text-gray-600 text-xs mb-1">{$i18n.t('OUTPUT')}</div>
 								<div class="text-sm">{codeExecution?.result?.output}</div>
 							</div>
 						{/if}

--- a/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
+++ b/src/lib/components/chat/Messages/Markdown/MarkdownTokens.svelte
@@ -102,7 +102,7 @@
 		<div class="relative w-full group">
 			<div class="scrollbar-hidden relative overflow-x-auto max-w-full rounded-lg">
 				<table
-					class=" w-full text-sm text-left text-gray-500 dark:text-gray-400 max-w-full rounded-xl"
+					class=" w-full text-sm text-left text-gray-600 dark:text-gray-400 max-w-full rounded-xl"
 				>
 					<thead
 						class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-gray-850 dark:text-gray-400 border-none"

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -561,7 +561,7 @@
 											<div
 												class="{status?.done === false
 													? 'shimmer'
-													: ''} text-gray-500 dark:text-gray-500 text-base line-clamp-1 text-wrap"
+													: ''} text-gray-600 dark:text-gray-500 text-base line-clamp-1 text-wrap"
 											>
 												{$i18n.t(`Searching Knowledge for "{{searchQuery}}"`, {
 													searchQuery: status.query
@@ -573,7 +573,7 @@
 											<div
 												class="{status?.done === false
 													? 'shimmer'
-													: ''} text-gray-500 dark:text-gray-500 text-base line-clamp-1 text-wrap"
+													: ''} text-gray-600 dark:text-gray-500 text-base line-clamp-1 text-wrap"
 											>
 												<!-- $i18n.t(`Searching "{{searchQuery}}"`) -->
 												{#if status?.description.includes('{{searchQuery}}')}

--- a/src/lib/components/chat/Messages/ResponseMessage/WebSearchResults.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage/WebSearchResults.svelte
@@ -10,7 +10,7 @@
 
 <Collapsible bind:open={state} className="w-full space-y-1">
 	<div
-		class="flex items-center gap-2 text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition"
+		class="flex items-center gap-2 text-gray-600 hover:text-gray-700 dark:hover:text-gray-300 transition"
 	>
 		<slot />
 

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -101,7 +101,7 @@
 				<Name>
 					{#if message.user}
 						{$i18n.t('You')}
-						<span class=" text-gray-500 text-sm font-medium">{message?.user ?? ''}</span>
+						<span class=" text-gray-600 text-sm font-medium">{message?.user ?? ''}</span>
 					{:else if $settings.showUsername || $_user.name !== user.name}
 						{user.name}
 					{:else}

--- a/src/lib/components/chat/ModelSelector.svelte
+++ b/src/lib/components/chat/ModelSelector.svelte
@@ -115,7 +115,7 @@
 </div>
 
 {#if showSetDefault && $config?.features?.enable_set_as_default_model}
-	<div class=" absolute text-left mt-[1px] ml-1 text-[0.7rem] text-gray-500 font-primary">
+	<div class=" absolute text-left mt-[1px] ml-1 text-[0.7rem] text-gray-600 font-primary">
 		<button on:click={saveDefaultModel}> {$i18n.t('Set as default')}</button>
 	</div>
 {/if}

--- a/src/lib/components/chat/Overview/Node.svelte
+++ b/src/lib/components/chat/Overview/Node.svelte
@@ -34,7 +34,7 @@
 					{#if data?.message?.error}
 						<div class="text-red-500 line-clamp-2 text-xs mt-0.5">{data.message.error.content}</div>
 					{:else}
-						<div class="text-gray-500 line-clamp-2 text-xs mt-0.5">{data.message.content}</div>
+						<div class="text-gray-600 line-clamp-2 text-xs mt-0.5">{data.message.content}</div>
 					{/if}
 				</div>
 			</div>
@@ -71,7 +71,7 @@
 							{data.message.error.content}
 						</div>
 					{:else}
-						<div class="text-gray-500 line-clamp-2 text-xs mt-0.5">{data.message.content}</div>
+						<div class="text-gray-600 line-clamp-2 text-xs mt-0.5">{data.message.content}</div>
 					{/if}
 				</div>
 			</div>

--- a/src/lib/components/chat/Placeholder.svelte
+++ b/src/lib/components/chat/Placeholder.svelte
@@ -93,7 +93,7 @@
 			className="w-full flex justify-center mb-0.5"
 			placement="top"
 		>
-			<div class="flex items-center gap-2 text-gray-500 font-medium text-lg my-2 w-fit">
+			<div class="flex items-center gap-2 text-gray-600 font-medium text-lg my-2 w-fit">
 				<EyeSlash strokeWidth="2.5" className="size-5" /> Temporary Chat
 			</div>
 		</Tooltip>
@@ -153,7 +153,7 @@
 							placement="top"
 						>
 							<div
-								class="mt-0.5 px-2 text-sm font-normal text-gray-500 dark:text-gray-400 line-clamp-2 max-w-xl markdown"
+								class="mt-0.5 px-2 text-sm font-normal text-gray-600 dark:text-gray-400 line-clamp-2 max-w-xl markdown"
 							>
 								{@html marked.parse(
 									sanitizeResponseContent(models[selectedModelIdx]?.info?.meta?.description)

--- a/src/lib/components/chat/Placeholder.svelte
+++ b/src/lib/components/chat/Placeholder.svelte
@@ -137,9 +137,9 @@
 					</div>
 				{/if}
 
-				<div class="text-xl lg:text-3xl sm:text-2xl line-clamp-1" in:fade={{ duration: 100 }}>
+				<h1 class="text-xl lg:text-3xl sm:text-2xl line-clamp-1" in:fade={{ duration: 100 }}>
 					{$i18n.t('How can I help you today?')}
-				</div>
+				</h1>
 			</div>
 
 			<div class="flex mt-1 mb-2">

--- a/src/lib/components/chat/Settings/About.svelte
+++ b/src/lib/components/chat/Settings/About.svelte
@@ -71,7 +71,7 @@
 					</div>
 
 					<button
-						class=" underline flex items-center space-x-1 text-xs text-gray-500 dark:text-gray-500"
+						class=" underline flex items-center space-x-1 text-xs text-gray-600 dark:text-gray-500"
 						on:click={() => {
 							showChangelog.set(true);
 						}}
@@ -137,11 +137,11 @@
 
 		<div class="mt-2 text-xs text-gray-400 dark:text-gray-500">
 			{#if !$WEBUI_NAME.includes('Open WebUI')}
-				<span class=" text-gray-500 dark:text-gray-300 font-medium">{$WEBUI_NAME}</span> -
+				<span class=" text-gray-600 dark:text-gray-300 font-medium">{$WEBUI_NAME}</span> -
 			{/if}
 			{$i18n.t('Created by')}
 			<a
-				class=" text-gray-500 dark:text-gray-300 font-medium"
+				class=" text-gray-600 dark:text-gray-300 font-medium"
 				href="https://github.com/tjbck"
 				target="_blank">Timothy J. Baek</a
 			>

--- a/src/lib/components/chat/Settings/Account.svelte
+++ b/src/lib/components/chat/Settings/Account.svelte
@@ -265,7 +265,7 @@
 		<div class="flex justify-between items-center text-sm">
 			<div class="  font-medium">{$i18n.t('API keys')}</div>
 			<button
-				class=" text-xs font-medium text-gray-500"
+				class=" text-xs font-medium text-gray-600"
 				type="button"
 				on:click={() => {
 					showAPIKeys = !showAPIKeys;

--- a/src/lib/components/chat/Settings/Account/UpdatePassword.svelte
+++ b/src/lib/components/chat/Settings/Account/UpdatePassword.svelte
@@ -45,7 +45,7 @@
 	<div class="flex justify-between items-center text-sm">
 		<div class="  font-medium">{$i18n.t('Change Password')}</div>
 		<button
-			class=" text-xs font-medium text-gray-500"
+			class=" text-xs font-medium text-gray-600"
 			type="button"
 			on:click={() => {
 				show = !show;
@@ -56,7 +56,7 @@
 	{#if show}
 		<div class=" py-2.5 space-y-1.5">
 			<div class="flex flex-col w-full">
-				<div class=" mb-1 text-xs text-gray-500">{$i18n.t('Current Password')}</div>
+				<div class=" mb-1 text-xs text-gray-600">{$i18n.t('Current Password')}</div>
 
 				<div class="flex-1">
 					<input
@@ -71,7 +71,7 @@
 			</div>
 
 			<div class="flex flex-col w-full">
-				<div class=" mb-1 text-xs text-gray-500">{$i18n.t('New Password')}</div>
+				<div class=" mb-1 text-xs text-gray-600">{$i18n.t('New Password')}</div>
 
 				<div class="flex-1">
 					<input
@@ -86,7 +86,7 @@
 			</div>
 
 			<div class="flex flex-col w-full">
-				<div class=" mb-1 text-xs text-gray-500">{$i18n.t('Confirm Password')}</div>
+				<div class=" mb-1 text-xs text-gray-600">{$i18n.t('Confirm Password')}</div>
 
 				<div class="flex-1">
 					<input

--- a/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
+++ b/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
@@ -975,7 +975,7 @@
 
 			{#if (params?.use_mmap ?? null) !== null}
 				<div class="flex justify-between items-center mt-1">
-					<div class="text-xs text-gray-500">
+					<div class="text-xs text-gray-600">
 						{params.use_mmap ? 'Enabled' : 'Disabled'}
 					</div>
 					<div class=" pr-2">
@@ -1016,7 +1016,7 @@
 
 			{#if (params?.use_mlock ?? null) !== null}
 				<div class="flex justify-between items-center mt-1">
-					<div class="text-xs text-gray-500">
+					<div class="text-xs text-gray-600">
 						{params.use_mlock ? 'Enabled' : 'Disabled'}
 					</div>
 

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -199,7 +199,7 @@
 				</div>
 			</div>
 			{#if $i18n.language === 'en-US'}
-				<div class="mb-2 text-xs text-gray-400 dark:text-gray-500">
+				<div class="mb-2 text-xs text-gray-600 dark:text-gray-400">
 					Couldn't find your language?
 					<a
 						class=" text-gray-600 font-medium underline"

--- a/src/lib/components/chat/Settings/General.svelte
+++ b/src/lib/components/chat/Settings/General.svelte
@@ -202,7 +202,7 @@
 				<div class="mb-2 text-xs text-gray-400 dark:text-gray-500">
 					Couldn't find your language?
 					<a
-						class=" text-gray-300 font-medium underline"
+						class=" text-gray-600 font-medium underline"
 						href="https://github.com/open-webui/open-webui/blob/main/docs/CONTRIBUTING.md#-translations-and-internationalization"
 						target="_blank"
 					>
@@ -247,7 +247,7 @@
 			<div class="flex justify-between items-center text-sm">
 				<div class="  font-medium">{$i18n.t('Advanced Parameters')}</div>
 				<button
-					class=" text-xs font-medium text-gray-500"
+					class=" text-xs font-medium text-gray-600"
 					type="button"
 					on:click={() => {
 						showAdvanced = !showAdvanced;

--- a/src/lib/components/chat/Settings/Personalization.svelte
+++ b/src/lib/components/chat/Settings/Personalization.svelte
@@ -42,7 +42,7 @@
 					<div class="text-sm font-medium">
 						{$i18n.t('Memory')}
 
-						<span class=" text-xs text-gray-500">({$i18n.t('Experimental')})</span>
+						<span class=" text-xs text-gray-600">({$i18n.t('Experimental')})</span>
 					</div>
 				</Tooltip>
 

--- a/src/lib/components/chat/Settings/Personalization/AddMemoryModal.svelte
+++ b/src/lib/components/chat/Settings/Personalization/AddMemoryModal.svelte
@@ -77,7 +77,7 @@
 							placeholder={$i18n.t('Enter a detail about yourself for your LLMs to recall')}
 						/>
 
-						<div class="text-xs text-gray-500">
+						<div class="text-xs text-gray-600">
 							ⓘ {$i18n.t('Refer to yourself as "User" (e.g., "User is learning Spanish")')}
 						</div>
 					</div>

--- a/src/lib/components/chat/Settings/Personalization/EditMemoryModal.svelte
+++ b/src/lib/components/chat/Settings/Personalization/EditMemoryModal.svelte
@@ -87,7 +87,7 @@
 							placeholder={$i18n.t('Enter a detail about yourself for your LLMs to recall')}
 						/>
 
-						<div class="text-xs text-gray-500">
+						<div class="text-xs text-gray-600">
 							ⓘ {$i18n.t('Refer to yourself as "User" (e.g., "User is learning Spanish")')}
 						</div>
 					</div>

--- a/src/lib/components/chat/Settings/Personalization/ManageModal.svelte
+++ b/src/lib/components/chat/Settings/Personalization/ManageModal.svelte
@@ -145,7 +145,7 @@
 					</div>
 				{:else}
 					<div class="text-center flex h-full text-sm w-full">
-						<div class=" my-auto pb-10 px-4 w-full text-gray-500">
+						<div class=" my-auto pb-10 px-4 w-full text-gray-600">
 							{$i18n.t('Memories accessible by LLMs will be shown here.')}
 						</div>
 					</div>

--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -384,7 +384,7 @@
 								class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-left transition {selectedTab ===
 								'general'
 									? ''
-									: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 								on:click={() => {
 									selectedTab = 'general';
 								}}
@@ -410,7 +410,7 @@
 								class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-left transition {selectedTab ===
 								'interface'
 									? ''
-									: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 								on:click={() => {
 									selectedTab = 'interface';
 								}}
@@ -436,7 +436,7 @@
 								class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-left transition {selectedTab ===
 								'personalization'
 									? ''
-									: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 								on:click={() => {
 									selectedTab = 'personalization';
 								}}
@@ -451,7 +451,7 @@
 								class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-left transition {selectedTab ===
 								'audio'
 									? ''
-									: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 								on:click={() => {
 									selectedTab = 'audio';
 								}}
@@ -478,7 +478,7 @@
 								class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-left transition {selectedTab ===
 								'chats'
 									? ''
-									: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 								on:click={() => {
 									selectedTab = 'chats';
 								}}
@@ -504,7 +504,7 @@
 								class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-left transition {selectedTab ===
 								'account'
 									? ''
-									: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 								on:click={() => {
 									selectedTab = 'account';
 								}}
@@ -530,7 +530,7 @@
 								class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-left transition {selectedTab ===
 								'about'
 									? ''
-									: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 								on:click={() => {
 									selectedTab = 'about';
 								}}
@@ -557,7 +557,7 @@
 									class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-left transition {selectedTab ===
 									'admin'
 										? ''
-										: ' text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+										: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
 									on:click={async () => {
 										await goto('/admin/settings');
 										show = false;
@@ -583,7 +583,7 @@
 						{/if}
 					{/each}
 				{:else}
-					<div class="text-center text-gray-500 mt-4">
+					<div class="text-center text-gray-600 mt-4">
 						{$i18n.t('No results found')}
 					</div>
 				{/if}

--- a/src/lib/components/chat/Suggestions.svelte
+++ b/src/lib/components/chat/Suggestions.svelte
@@ -45,7 +45,7 @@
 					>
 						{prompt.content}
 					</div>
-					<div class="text-xs text-gray-500 font-normal line-clamp-1">Prompt</div>
+					<div class="text-xs text-gray-600 font-normal line-clamp-1">Prompt</div>
 				{/if}
 			</div>
 		</button>

--- a/src/lib/components/chat/Suggestions.svelte
+++ b/src/lib/components/chat/Suggestions.svelte
@@ -16,10 +16,10 @@
 </script>
 
 {#if prompts.length > 0}
-	<div class="mb-1 flex gap-1 text-sm font-medium items-center text-gray-400 dark:text-gray-600">
+	<h2 class="mb-1 flex gap-1 text-sm font-medium items-center text-gray-600 dark:text-gray-400">
 		<Bolt />
 		{$i18n.t('Suggested prompts to get you started')}
-	</div>
+	</h2>
 {/if}
 
 <div

--- a/src/lib/components/common/Collapsible.svelte
+++ b/src/lib/components/common/Collapsible.svelte
@@ -13,7 +13,7 @@
 	export let open = false;
 	export let className = '';
 	export let buttonClassName =
-		'w-fit text-gray-500 hover:text-gray-700 dark:hover:text-gray-300 transition';
+		'w-fit text-gray-600 hover:text-gray-700 dark:hover:text-gray-300 transition';
 	export let title = null;
 
 	export let grow = false;

--- a/src/lib/components/common/ConfirmDialog.svelte
+++ b/src/lib/components/common/ConfirmDialog.svelte
@@ -88,7 +88,7 @@
 				</div>
 
 				<slot>
-					<div class=" text-sm text-gray-500 flex-1">
+					<div class=" text-sm text-gray-600 flex-1">
 						{#if message !== ''}
 							{message}
 						{:else}

--- a/src/lib/components/common/FileItem.svelte
+++ b/src/lib/components/common/FileItem.svelte
@@ -83,7 +83,7 @@
 				{name}
 			</div>
 
-			<div class=" flex justify-between text-gray-500 text-xs line-clamp-1">
+			<div class=" flex justify-between text-gray-600 text-xs line-clamp-1">
 				{#if type === 'file'}
 					{$i18n.t('File')}
 				{:else if type === 'doc'}
@@ -108,7 +108,7 @@
 						</div>
 					{/if}
 					<div class="font-medium line-clamp-1 flex-1">{name}</div>
-					<div class="text-gray-500 text-xs capitalize shrink-0">{formatFileSize(size)}</div>
+					<div class="text-gray-600 text-xs capitalize shrink-0">{formatFileSize(size)}</div>
 				</div>
 			</div>
 		</Tooltip>

--- a/src/lib/components/common/FileItemModal.svelte
+++ b/src/lib/components/common/FileItemModal.svelte
@@ -55,7 +55,7 @@
 
 			<div>
 				<div class="flex flex-col items-center md:flex-row gap-1 justify-between w-full">
-					<div class=" flex flex-wrap text-sm gap-1 text-gray-500">
+					<div class=" flex flex-wrap text-sm gap-1 text-gray-600">
 						{#if item.size}
 							<div class="capitalize shrink-0">{formatFileSize(item.size)}</div>
 							•

--- a/src/lib/components/common/Folder.svelte
+++ b/src/lib/components/common/Folder.svelte
@@ -127,10 +127,10 @@
 		>
 			<!-- svelte-ignore a11y-no-static-element-interactions -->
 			<div
-				class="w-full group rounded-md relative flex items-center justify-between hover:bg-gray-100 dark:hover:bg-gray-900 text-gray-500 dark:text-gray-500 transition"
+				class="w-full group rounded-md relative flex items-center justify-between hover:bg-gray-100 dark:hover:bg-gray-900 text-gray-600 dark:text-gray-500 transition"
 			>
 				<button class="w-full py-1.5 pl-2 flex items-center gap-1.5 text-xs font-medium">
-					<div class="text-gray-300 dark:text-gray-600">
+					<div class="text-gray-600 dark:text-gray-600">
 						{#if open}
 							<ChevronDown className=" size-3" strokeWidth="2.5" />
 						{:else}

--- a/src/lib/components/common/Valves.svelte
+++ b/src/lib/components/common/Valves.svelte
@@ -17,7 +17,7 @@
 					{valvesSpec.properties[property].title}
 
 					{#if (valvesSpec?.required ?? []).includes(property)}
-						<span class=" text-gray-500">*required</span>
+						<span class=" text-gray-600">*required</span>
 					{/if}
 				</div>
 
@@ -67,7 +67,7 @@
 							</select>
 						{:else if (valvesSpec.properties[property]?.type ?? null) === 'boolean'}
 							<div class="flex justify-between items-center">
-								<div class="text-xs text-gray-500">
+								<div class="text-xs text-gray-600">
 									{valves[property] ? 'Enabled' : 'Disabled'}
 								</div>
 
@@ -98,7 +98,7 @@
 			{/if}
 
 			{#if (valvesSpec.properties[property]?.description ?? null) !== null}
-				<div class="text-xs text-gray-500">
+				<div class="text-xs text-gray-600">
 					{valvesSpec.properties[property].description}
 				</div>
 			{/if}

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -566,7 +566,7 @@
 				<div class="absolute z-40 right-3.5 top-1">
 					<Tooltip content={$i18n.t('New folder')}>
 						<button
-							class="p-1 rounded-lg bg-gray-50 hover:bg-gray-100 dark:bg-gray-950 dark:hover:bg-gray-900 text-gray-500 dark:text-gray-500 transition"
+							class="p-1 rounded-lg bg-gray-50 hover:bg-gray-100 dark:bg-gray-950 dark:hover:bg-gray-900 text-gray-600 dark:text-gray-500 transition"
 							on:click={() => {
 								createFolder();
 							}}
@@ -761,7 +761,7 @@
 							{#each $chats as chat, idx}
 								{#if idx === 0 || (idx > 0 && chat.time_range !== $chats[idx - 1].time_range)}
 									<div
-										class="w-full pl-2.5 text-xs text-gray-500 dark:text-gray-500 font-medium {idx ===
+										class="w-full pl-2.5 text-xs text-gray-600 dark:text-gray-500 font-medium {idx ===
 										0
 											? ''
 											: 'pt-5'} pb-1.5"

--- a/src/lib/components/layout/Sidebar/ChannelModal.svelte
+++ b/src/lib/components/layout/Sidebar/ChannelModal.svelte
@@ -91,7 +91,7 @@
 					}}
 				>
 					<div class="flex flex-col w-full mt-2">
-						<div class=" mb-1 text-xs text-gray-500">{$i18n.t('Channel Name')}</div>
+						<div class=" mb-1 text-xs text-gray-600">{$i18n.t('Channel Name')}</div>
 
 						<div class="flex-1">
 							<input

--- a/src/lib/components/layout/Sidebar/ChatItem.svelte
+++ b/src/lib/components/layout/Sidebar/ChatItem.svelte
@@ -203,7 +203,7 @@
 		deleteChatHandler(id);
 	}}
 >
-	<div class=" text-sm text-gray-500 flex-1 line-clamp-3">
+	<div class=" text-sm text-gray-600 flex-1 line-clamp-3">
 		{$i18n.t('This will delete')} <span class="  font-semibold">{title}</span>.
 	</div>
 </DeleteConfirmDialog>

--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -375,12 +375,12 @@
 		<div class="w-full group">
 			<button
 				id="folder-{folderId}-button"
-				class="relative w-full py-1.5 px-2 rounded-md flex items-center gap-1.5 text-xs text-gray-500 dark:text-gray-500 font-medium hover:bg-gray-100 dark:hover:bg-gray-900 transition"
+				class="relative w-full py-1.5 px-2 rounded-md flex items-center gap-1.5 text-xs text-gray-600 dark:text-gray-500 font-medium hover:bg-gray-100 dark:hover:bg-gray-900 transition"
 				on:dblclick={() => {
 					editHandler();
 				}}
 			>
-				<div class="text-gray-300 dark:text-gray-600">
+				<div class="text-gray-600 dark:text-gray-600">
 					{#if open}
 						<ChevronDown className=" size-3" strokeWidth="2.5" />
 					{:else}
@@ -412,7 +412,7 @@
 									edit = false;
 								}
 							}}
-							class="w-full h-full bg-transparent text-gray-500 dark:text-gray-500 outline-none"
+							class="w-full h-full bg-transparent text-gray-600 dark:text-gray-500 outline-none"
 						/>
 					{:else}
 						{folders[folderId].name}

--- a/src/lib/components/layout/Sidebar/SearchInput.svelte
+++ b/src/lib/components/layout/Sidebar/SearchInput.svelte
@@ -183,7 +183,7 @@
 									{tag.name}
 								</div>
 
-								<div class=" text-gray-500 line-clamp-1">
+								<div class=" text-gray-600 line-clamp-1">
 									{tag.id}
 								</div>
 							</button>
@@ -215,7 +215,7 @@
 							>
 								<div class="dark:text-gray-300 text-gray-700 font-medium">{option.name}</div>
 
-								<div class=" text-gray-500 line-clamp-1">
+								<div class=" text-gray-600 line-clamp-1">
 									{option.description}
 								</div>
 							</button>

--- a/src/lib/components/playground/Chat.svelte
+++ b/src/lib/components/playground/Chat.svelte
@@ -239,7 +239,7 @@
 						</div>
 
 						{#if !showSystem}
-							<div class=" flex-1 text-gray-500 line-clamp-1">
+							<div class=" flex-1 text-gray-600 line-clamp-1">
 								{system}
 							</div>
 						{/if}
@@ -293,7 +293,7 @@
 			</div>
 
 			<div class="pb-3">
-				<div class="text-xs font-medium text-gray-500 px-2 py-1">
+				<div class="text-xs font-medium text-gray-600 px-2 py-1">
 					{selectedModelId}
 				</div>
 				<div class="border border-gray-50 dark:border-gray-850 w-full px-3 py-2.5 rounded-xl">

--- a/src/lib/components/workspace/Knowledge.svelte
+++ b/src/lib/components/workspace/Knowledge.svelte
@@ -89,7 +89,7 @@
 			<div class="flex md:self-center text-xl font-medium px-0.5 items-center">
 				{$i18n.t('Knowledge')}
 				<div class="flex self-center w-[1px] h-6 mx-2.5 bg-gray-50 dark:bg-gray-850" />
-				<span class="text-lg font-medium text-gray-500 dark:text-gray-300"
+				<span class="text-lg font-medium text-gray-600 dark:text-gray-300"
 					>{filteredItems.length}</span
 				>
 			</div>
@@ -163,7 +163,7 @@
 						</div>
 
 						<div class="mt-3 flex justify-between">
-							<div class="text-xs text-gray-500">
+							<div class="text-xs text-gray-600">
 								<Tooltip
 									content={item?.user?.email ?? $i18n.t('Deleted User')}
 									className="flex shrink-0"
@@ -176,7 +176,7 @@
 									})}
 								</Tooltip>
 							</div>
-							<div class=" text-xs text-gray-500 line-clamp-1">
+							<div class=" text-xs text-gray-600 line-clamp-1">
 								{$i18n.t('Updated')}
 								{dayjs(item.updated_at * 1000).fromNow()}
 							</div>
@@ -187,7 +187,7 @@
 		{/each}
 	</div>
 
-	<div class=" text-gray-500 text-xs mt-1 mb-2">
+	<div class=" text-gray-600 text-xs mt-1 mb-2">
 		ⓘ {$i18n.t("Use '#' in the prompt input to load and include your knowledge.")}
 	</div>
 {:else}

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -653,7 +653,7 @@
 					<div class="flex w-full px-1">
 						<input
 							type="text"
-							class="text-left text-xs w-full text-gray-500 bg-transparent outline-none"
+							class="text-left text-xs w-full text-gray-600 bg-transparent outline-none"
 							bind:value={knowledge.description}
 							placeholder="Knowledge Description"
 							on:input={() => {
@@ -855,7 +855,7 @@
 								/>
 							</div>
 						{:else}
-							<div class="my-3 flex flex-col justify-center text-center text-gray-500 text-xs">
+							<div class="my-3 flex flex-col justify-center text-center text-gray-600 text-xs">
 								<div>
 									{$i18n.t('No content found')}
 								</div>

--- a/src/lib/components/workspace/Models.svelte
+++ b/src/lib/components/workspace/Models.svelte
@@ -201,7 +201,7 @@
 			<div class="flex items-center md:self-center text-xl font-medium px-0.5">
 				{$i18n.t('Models')}
 				<div class="flex self-center w-[1px] h-6 mx-2.5 bg-gray-50 dark:bg-gray-850" />
-				<span class="text-lg font-medium text-gray-500 dark:text-gray-300"
+				<span class="text-lg font-medium text-gray-600 dark:text-gray-300"
 					>{filteredModels.length}</span
 				>
 			</div>
@@ -255,7 +255,7 @@
 						class=" flex flex-1 cursor-pointer w-full"
 						href={`/?models=${encodeURIComponent(model.id)}`}
 					>
-						<div class=" flex-1 self-center {model.is_active ? '' : 'text-gray-500'}">
+						<div class=" flex-1 self-center {model.is_active ? '' : 'text-gray-600'}">
 							<Tooltip
 								content={marked.parse(model?.meta?.description ?? model.id)}
 								className=" w-fit"
@@ -284,7 +284,7 @@
 							className="flex shrink-0"
 							placement="top-start"
 						>
-							<div class="shrink-0 text-gray-500">
+							<div class="shrink-0 text-gray-600">
 								{$i18n.t('By {{name}}', {
 									name: capitalizeFirstLetter(
 										model?.user?.name ?? model?.user?.email ?? $i18n.t('Deleted User')

--- a/src/lib/components/workspace/Models/Knowledge/Selector.svelte
+++ b/src/lib/components/workspace/Models/Knowledge/Selector.svelte
@@ -118,7 +118,7 @@
 
 			<div class="max-h-48 overflow-y-scroll">
 				{#if filteredItems.length === 0}
-					<div class="text-center text-sm text-gray-500 dark:text-gray-400">
+					<div class="text-center text-sm text-gray-600 dark:text-gray-400">
 						{$i18n.t('No knowledge found')}
 					</div>
 				{:else}

--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -408,7 +408,7 @@
 
 						<div class="flex w-full mt-1 justify-end">
 							<button
-								class="px-2 py-1 text-gray-500 rounded-lg text-xs"
+								class="px-2 py-1 text-gray-600 rounded-lg text-xs"
 								on:click={() => {
 									info.meta.profile_image_url = '/static/favicon.png';
 								}}
@@ -436,7 +436,7 @@
 						<div class="flex-1">
 							<div>
 								<input
-									class="text-xs w-full bg-transparent text-gray-500 outline-none"
+									class="text-xs w-full bg-transparent text-gray-600 outline-none"
 									placeholder={$i18n.t('Model ID')}
 									bind:value={id}
 									disabled={edit}
@@ -709,7 +709,7 @@
 						<Capabilities bind:capabilities />
 					</div>
 
-					<div class="my-2 text-gray-300 dark:text-gray-700">
+					<div class="my-2 text-gray-600 dark:text-gray-700">
 						<div class="flex w-full justify-between mb-2">
 							<div class=" self-center text-sm font-semibold">{$i18n.t('JSON Preview')}</div>
 

--- a/src/lib/components/workspace/Prompts.svelte
+++ b/src/lib/components/workspace/Prompts.svelte
@@ -100,7 +100,7 @@
 			deleteHandler(deletePrompt);
 		}}
 	>
-		<div class=" text-sm text-gray-500">
+		<div class=" text-sm text-gray-600">
 			{$i18n.t('This will delete')} <span class="  font-semibold">{deletePrompt.command}</span>.
 		</div>
 	</DeleteConfirmDialog>
@@ -110,7 +110,7 @@
 			<div class="flex md:self-center text-xl font-medium px-0.5 items-center">
 				{$i18n.t('Prompts')}
 				<div class="flex self-center w-[1px] h-6 mx-2.5 bg-gray-50 dark:bg-gray-850" />
-				<span class="text-lg font-medium text-gray-500 dark:text-gray-300"
+				<span class="text-lg font-medium text-gray-600 dark:text-gray-300"
 					>{filteredItems.length}</span
 				>
 			</div>
@@ -159,7 +159,7 @@
 								className="flex shrink-0"
 								placement="top-start"
 							>
-								<div class="shrink-0 text-gray-500">
+								<div class="shrink-0 text-gray-600">
 									{$i18n.t('By {{name}}', {
 										name: capitalizeFirstLetter(
 											prompt?.user?.name ?? prompt?.user?.email ?? $i18n.t('Deleted User')

--- a/src/lib/components/workspace/Prompts/PromptEditor.svelte
+++ b/src/lib/components/workspace/Prompts/PromptEditor.svelte
@@ -113,7 +113,7 @@
 						</div>
 					</div>
 
-					<div class="flex gap-0.5 items-center text-xs text-gray-500">
+					<div class="flex gap-0.5 items-center text-xs text-gray-600">
 						<div class="">/</div>
 						<input
 							class=" w-full bg-transparent outline-none"

--- a/src/lib/components/workspace/Tools.svelte
+++ b/src/lib/components/workspace/Tools.svelte
@@ -178,7 +178,7 @@
 			<div class="flex md:self-center text-xl font-medium px-0.5 items-center">
 				{$i18n.t('Tools')}
 				<div class="flex self-center w-[1px] h-6 mx-2.5 bg-gray-50 dark:bg-gray-850" />
-				<span class="text-lg font-medium text-gray-500 dark:text-gray-300"
+				<span class="text-lg font-medium text-gray-600 dark:text-gray-300"
 					>{filteredItems.length}</span
 				>
 			</div>
@@ -237,7 +237,7 @@
 									<div class="line-clamp-1">
 										{tool.name}
 
-										<span class=" text-gray-500 text-xs font-medium flex-shrink-0">{tool.id}</span>
+										<span class=" text-gray-600 text-xs font-medium flex-shrink-0">{tool.id}</span>
 									</div>
 								</div>
 							</Tooltip>
@@ -249,7 +249,7 @@
 									</div>
 								</div>
 
-								<div class="text-xs text-gray-500 shrink-0">
+								<div class="text-xs text-gray-600 shrink-0">
 									<Tooltip
 										content={tool?.user?.email ?? $i18n.t('Deleted User')}
 										className="flex shrink-0"
@@ -469,7 +469,7 @@
 			deleteHandler(selectedTool);
 		}}
 	>
-		<div class=" text-sm text-gray-500">
+		<div class=" text-sm text-gray-600">
 			{$i18n.t('This will delete')} <span class="  font-semibold">{selectedTool.name}</span>.
 		</div>
 	</DeleteConfirmDialog>
@@ -499,7 +499,7 @@
 			reader.readAsText(importFiles[0]);
 		}}
 	>
-		<div class="text-sm text-gray-500">
+		<div class="text-sm text-gray-600">
 			<div class=" bg-yellow-500/20 text-yellow-700 dark:text-yellow-200 rounded-lg px-4 py-3">
 				<div>{$i18n.t('Please carefully review the following warnings:')}</div>
 

--- a/src/lib/components/workspace/Tools/ToolkitEditor.svelte
+++ b/src/lib/components/workspace/Tools/ToolkitEditor.svelte
@@ -242,7 +242,7 @@ class Tools:
 
 					<div class=" flex gap-2 px-1 items-center">
 						{#if edit}
-							<div class="text-sm text-gray-500 flex-shrink-0">
+							<div class="text-sm text-gray-600 flex-shrink-0">
 								{id}
 							</div>
 						{:else}
@@ -293,7 +293,7 @@ class Tools:
 
 				<div class="pb-3 flex justify-between">
 					<div class="flex-1 pr-3">
-						<div class="text-xs text-gray-500 line-clamp-2">
+						<div class="text-xs text-gray-600 line-clamp-2">
 							<span class=" font-semibold dark:text-gray-200">{$i18n.t('Warning:')}</span>
 							{$i18n.t('Tools are a function calling system with arbitrary code execution')} <br />—
 							<span class=" font-medium dark:text-gray-400"
@@ -320,7 +320,7 @@ class Tools:
 		submitHandler();
 	}}
 >
-	<div class="text-sm text-gray-500">
+	<div class="text-sm text-gray-600">
 		<div class=" bg-yellow-500/20 text-yellow-700 dark:text-yellow-200 rounded-lg px-4 py-3">
 			<div>{$i18n.t('Please carefully review the following warnings:')}</div>
 

--- a/src/lib/components/workspace/common/AccessControl.svelte
+++ b/src/lib/components/workspace/common/AccessControl.svelte
@@ -154,7 +154,7 @@
 						{/each}
 					{:else}
 						<div class="flex items-center justify-center">
-							<div class="text-gray-500 text-xs text-center py-2 px-10">
+							<div class="text-gray-600 text-xs text-center py-2 px-10">
 								{$i18n.t('No groups with access, add a group to grant access')}
 							</div>
 						</div>

--- a/src/routes/(app)/admin/+layout.svelte
+++ b/src/routes/(app)/admin/+layout.svelte
@@ -58,28 +58,28 @@
 						<a
 							class="min-w-fit rounded-full p-1.5 {['/admin/users'].includes($page.url.pathname)
 								? ''
-								: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+								: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
 							href="/admin">{$i18n.t('Users')}</a
 						>
 
 						<a
 							class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/admin/evaluations')
 								? ''
-								: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+								: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
 							href="/admin/evaluations">{$i18n.t('Evaluations')}</a
 						>
 
 						<a
 							class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/admin/functions')
 								? ''
-								: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+								: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
 							href="/admin/functions">{$i18n.t('Functions')}</a
 						>
 
 						<a
 							class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/admin/settings')
 								? ''
-								: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+								: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
 							href="/admin/settings">{$i18n.t('Settings')}</a
 						>
 					</div>

--- a/src/routes/(app)/playground/+layout.svelte
+++ b/src/routes/(app)/playground/+layout.svelte
@@ -50,14 +50,14 @@
 							$page.url.pathname
 						)
 							? ''
-							: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+							: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
 						href="/playground">{$i18n.t('Chat')}</a
 					>
 
 					<!-- <a
 						class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/playground/notes')
 							? ''
-							: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+							: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
 						href="/playground/notes">{$i18n.t('Notes')}</a
 					> -->
 
@@ -66,7 +66,7 @@
 							'/playground/completions'
 						)
 							? ''
-							: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+							: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
 						href="/playground/completions">{$i18n.t('Completions')}</a
 					>
 				</div>

--- a/src/routes/(app)/workspace/+layout.svelte
+++ b/src/routes/(app)/workspace/+layout.svelte
@@ -86,7 +86,7 @@
 									'/workspace/models'
 								)
 									? ''
-									: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+									: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
 								href="/workspace/models">{$i18n.t('Models')}</a
 							>
 						{/if}
@@ -97,7 +97,7 @@
 									'/workspace/knowledge'
 								)
 									? ''
-									: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+									: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
 								href="/workspace/knowledge"
 							>
 								{$i18n.t('Knowledge')}
@@ -110,7 +110,7 @@
 									'/workspace/prompts'
 								)
 									? ''
-									: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+									: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
 								href="/workspace/prompts">{$i18n.t('Prompts')}</a
 							>
 						{/if}
@@ -119,7 +119,7 @@
 							<a
 								class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/workspace/tools')
 									? ''
-									: 'text-gray-300 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+									: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
 								href="/workspace/tools"
 							>
 								{$i18n.t('Tools')}

--- a/src/routes/auth/+page.svelte
+++ b/src/routes/auth/+page.svelte
@@ -194,7 +194,7 @@
 								</h1>
 
 								{#if $config?.onboarding ?? false}
-									<div class=" mt-1 text-xs font-medium text-gray-500">
+									<div class=" mt-1 text-xs font-medium text-gray-600">
 										ⓘ {$WEBUI_NAME}
 										{$i18n.t(
 											'does not make any external connections, and your data stays securely on your locally hosted server.'

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,6 +6,7 @@ export default {
 	content: ['./src/**/*.{html,js,svelte,ts}'],
 	theme: {
 		extend: {
+			/* comment out customized colors 
 			colors: {
 				gray: {
 					50: '#f9f9f9',
@@ -22,6 +23,7 @@ export default {
 					950: 'var(--color-gray-950, #0d0d0d)'
 				}
 			},
+			*/
 			typography: {
 				DEFAULT: {
 					css: {

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -6,7 +6,6 @@ export default {
 	content: ['./src/**/*.{html,js,svelte,ts}'],
 	theme: {
 		extend: {
-			/* comment out customized colors 
 			colors: {
 				gray: {
 					50: '#f9f9f9',
@@ -23,7 +22,6 @@ export default {
 					950: 'var(--color-gray-950, #0d0d0d)'
 				}
 			},
-			*/
 			typography: {
 				DEFAULT: {
 					css: {


### PR DESCRIPTION
# Changelog Entry

## Description

This PR contains commits to provide short-term resolution to contrast issues described in #365 

## Fixed

- Addresses dozens of low contrast text issues in the light theme 
- Adds border around the chat-input field for improved visibility for low vision users 
- Provides better contrast for `:hover` and `:focus` states of the chat-input submit `button`
- Updates headings for heading-like content around the chat input _(ed/ this one is not contrast related but sue me for sneaking this fix into this PR)_

## ToDo

- [ ] Improve visual styling of current/active "tabs" in components like settings

## Screenshots showing fixes and to-dos

<img width="948" alt="settings-general-better-contrast" src="https://github.com/user-attachments/assets/98c52538-b5d1-4e1a-9a71-46d22063af77" />
<img width="1459" alt="main-chat-improved-contrast" src="https://github.com/user-attachments/assets/784a6d61-3daf-41a7-bd2b-c3122a12f596" />

