### PR TITLE
FIX: get new chat button to trigger new chat from another new chat

### DIFF
--- a/src/lib/components/chat/Navbar.svelte
+++ b/src/lib/components/chat/Navbar.svelte
@@ -74,6 +74,7 @@
 				{#if !$mobile}
 					<Tooltip content={$i18n.t('New Chat')}>
 						<button
+							id="new-chat-button"
 							class="ml-2 mr-4 {$showSidebar ? 'md:hidden' : ''}"
 							aria-label="New Chat"
 							on:click={() => {


### PR DESCRIPTION
Fixes issue with #265 where clicking the new chat icon in the sidebar from a page with a recent chat would not trigger a new chat.