### PR TITLE
fix suggested prompt font rendering in safari (#396)

### DIFF
--- a/src/lib/components/chat/Suggestions.svelte
+++ b/src/lib/components/chat/Suggestions.svelte
@@ -35,7 +35,7 @@
 			<div>
 				{#if prompt.title && prompt.title[0] !== ''}
 					<div
-						class="px-2 py-2 border border-gray-400 text-sm font-medium items-center text-gray-400 dark:text-gray-600 bg-transparent font-semibold rounded-full hover:text-gray-800 hover:border-gray-800 dark:text-gray-300 dark:border-gray-600 dark:hover:border-gray-100 dark:hover:text-gray-100"
+						class="px-2 py-2 border border-gray-400 text-sm items-center text-gray-400 dark:text-gray-600 bg-transparent rounded-full hover:text-gray-800 hover:border-gray-800 dark:text-gray-300 dark:border-gray-600 dark:hover:border-gray-100 dark:hover:text-gray-100"
 					>
 						{prompt.title[0]}
 					</div>


### PR DESCRIPTION
# Changelog Entry

### Description

- Fix for issue #396 (suggested prompts font rendering is too bold, almost unreadable in Safari) 

### Added

- Nothing

### Changed

- Suggestions.svelte classes

### Removed

- Removed classes `font-medium` and `font-semibold` for suggested prompts

### Fixed

- #396 

### Screenshots or Videos

<img width="1039" alt="Screenshot of Safari font rendering for suggested prompts" src="https://github.com/user-attachments/assets/74ce3eff-56da-4baa-b819-c165a4417b8a" />

