### PR TITLE
add GSA logo back

### DIFF
--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -496,9 +496,9 @@
 					<div class="self-center">
 						<img
 							crossorigin="anonymous"
-							src="{WEBUI_BASE_URL}/static/favicon.png"
-							class=" size-5 -translate-x-1.5 rounded-full"
-							alt={$WEBUI_NAME}
+							src="{WEBUI_BASE_URL}/static/gsa-logo.svg"
+							class="size-7 -translate-x-1.5"
+							alt="GSA"
 						/>
 					</div>
 					<div class=" self-center font-medium text-2xl text-gray-850 dark:text-white font-primary">


### PR DESCRIPTION
bring gsa logo back from the sidebar
<img width="980" alt="image" src="https://github.com/user-attachments/assets/41b684f4-e8b5-487c-aa25-3deff61f0b74" />
