### PR TITLE
address #424 - add help button label, fix svg code

### DIFF
--- a/src/lib/components/icons/QuestionMarkCircle.svelte
+++ b/src/lib/components/icons/QuestionMarkCircle.svelte
@@ -10,6 +10,8 @@
 	stroke-width={strokeWidth}
 	stroke="currentColor"
 	class={className}
+	role="img"
+	aria-hidden="true"
 >
 	<path
 		stroke-linecap="round"

--- a/src/lib/components/layout/Help.svelte
+++ b/src/lib/components/layout/Help.svelte
@@ -30,6 +30,7 @@
 	>
 		<Tooltip content={$i18n.t('Help')} placement="top">
 			<button
+				aria-label="help"
 				class="text-gray-600 dark:text-gray-300 bg-gray-300/20 flex items-center justify-center text-[0.7rem] rounded-full"
 			>
 				<QuestionMarkCircle className="size-5" />


### PR DESCRIPTION
# Changelog Entry

### Description

- Improves accessibility of the help button and icon

### Added

- `aria-label="help"` to the "help" `button`
- `role="img"` to the QuestionMarkCircle icon
- `aria-hidden="true"` to the QuestionMarkCircle icon

