### PR TITLE
Remove background color from dark and light chat-input #435

### DIFF
--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -539,7 +539,7 @@
 							}}
 						>
 							<div
-								class="flex-1 flex flex-col border border-gray-400 relative w-full rounded-3xl px-1 bg-gray-600/5 dark:bg-gray-400/5 dark:text-gray-100"
+								class="flex-1 flex flex-col border border-gray-400 relative w-full rounded-3xl px-1 dark:text-gray-100"
 								dir={$settings?.chatDirection ?? 'LTR'}
 							>
 								{#if files.length > 0}


### PR DESCRIPTION
# Changelog Entry

### Description

- UI change requested to remove the background color for the `chat-input` field for light and dark themes.

### Added

- none

### Changed

- MessageInput.svelte 

### Deprecated

- none

### Removed

- background color classes for `div` containing the `chat-input` field

### Fixed

- #435 

### Security

- none

### Breaking Changes

- none

---

### Additional Information

- none

### Screenshots or Videos

<img width="1101" alt="Screenshot 2025-03-19 at 2 57 42 PM" src="https://github.com/user-attachments/assets/04f525c7-f808-416d-876d-48e10dccba9d" />
<img width="1098" alt="Screenshot 2025-03-19 at 2 57 23 PM" src="https://github.com/user-attachments/assets/0568beb2-4279-4478-a0aa-5cae9ee7b8e8" />

