### PR TITLE
FIX: add aria labels to prev/next buttons

### DIFF
--- a/src/lib/components/chat/Artifacts.svelte
+++ b/src/lib/components/chat/Artifacts.svelte
@@ -247,6 +247,7 @@
 			<div class="flex items-center space-x-2">
 				<div class="flex items-center gap-0.5 self-center min-w-fit" dir="ltr">
 					<button
+						aria-label="show previous"
 						class="self-center p-1 hover:bg-black/5 dark:hover:bg-white/5 dark:hover:text-white hover:text-black rounded-md transition disabled:cursor-not-allowed"
 						on:click={() => navigateContent('prev')}
 						disabled={contents.length <= 1}
@@ -275,6 +276,7 @@
 					</div>
 
 					<button
+						aria-label="show next"
 						class="self-center p-1 hover:bg-black/5 dark:hover:bg-white/5 dark:hover:text-white hover:text-black rounded-md transition disabled:cursor-not-allowed"
 						on:click={() => navigateContent('next')}
 						disabled={contents.length <= 1}

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -735,6 +735,7 @@
 							{#if siblings.length > 1}
 								<div class="flex self-center min-w-fit" dir="ltr">
 									<button
+										aria-label="show previous message"
 										class="self-center p-1 hover:bg-black/5 dark:hover:bg-white/5 dark:hover:text-white hover:text-black rounded-md transition"
 										on:click={() => {
 											showPreviousMessage(message);
@@ -763,6 +764,7 @@
 									</div>
 
 									<button
+										aria-label="show next message"
 										class="self-center p-1 hover:bg-black/5 dark:hover:bg-white/5 dark:hover:text-white hover:text-black rounded-md transition"
 										on:click={() => {
 											showNextMessage(message);

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -229,6 +229,7 @@
 							{#if siblings.length > 1}
 								<div class="flex self-center" dir="ltr">
 									<button
+										aria-label="show previous message"
 										class="self-center p-1 hover:bg-black/5 dark:hover:bg-white/5 dark:hover:text-white hover:text-black rounded-md transition"
 										on:click={() => {
 											showPreviousMessage(message);
@@ -255,6 +256,7 @@
 									</div>
 
 									<button
+										aria-label="show next message"
 										class="self-center p-1 hover:bg-black/5 dark:hover:bg-white/5 dark:hover:text-white hover:text-black rounded-md transition"
 										on:click={() => {
 											showNextMessage(message);


### PR DESCRIPTION
# Changelog Entry

### Description

Adds aria-labels to message previous/next buttons (for example, when regenerating a message) so that screen readers provide more meaningful information. 

### Fixed

Accessibility for prev/next buttons

### Additional Information

How to test:
1) Go to a message and click "regenerate" under chat controls
2) prev/next buttons will appear as the first items under chat controls
3) read these buttons with a screen reader (I was using VO on Safari/Mac)

### Screenshots or Videos

![Screenshot 2025-03-25 at 1 26 52 PM](https://github.com/user-attachments/assets/39fd2463-282f-4986-aabb-79dbf7e19c7a)


