### PR TITLE
Fix timestamps

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -1,6 +1,8 @@
 :root {
 	--gsa-blue: #005087;
 	--gsa-blue-hover: #4d84aa;
+	--gsa-light-blue-hover: #77ccff;
+	--gray-550: #949494;
 }
 
 @font-face {
@@ -319,4 +321,16 @@ input[type='number'] {
 .bg-gsa-blue:focus,
 .bg-gsa-blue:hover {
 	background-color: var(--gsa-blue-hover);
+}
+
+.bg-gray-550 {
+	background-color: var(--gray-550);
+}
+
+button.outline-gsa-blue:focus {
+	outline-color: var(--gsa-blue);
+}
+
+.dark button.outline-gsa-blue:focus {
+	outline-color: var(--gsa-light-blue-hover);
 }

--- a/src/lib/components/admin/Evaluations.svelte
+++ b/src/lib/components/admin/Evaluations.svelte
@@ -44,7 +44,7 @@
 				class="px-0.5 py-1 min-w-fit rounded-lg lg:flex-none flex text-right transition {selectedTab ===
 				'leaderboard'
 					? ''
-					: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+					: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 				on:click={() => {
 					selectedTab = 'leaderboard';
 				}}
@@ -70,7 +70,7 @@
 					class="px-0.5 py-1 min-w-fit rounded-lg lg:flex-none flex text-right transition {selectedTab ===
 					'feedbacks'
 						? ''
-						: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+						: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 					on:click={() => {
 						selectedTab = 'feedbacks';
 					}}

--- a/src/lib/components/admin/Evaluations/Feedbacks.svelte
+++ b/src/lib/components/admin/Evaluations/Feedbacks.svelte
@@ -249,7 +249,7 @@
 
 {#if feedbacks.length > 0}
 	<div class=" flex flex-col justify-end w-full text-right gap-1">
-		<div class="line-clamp-1 text-gray-600 text-xs">
+		<div class="line-clamp-1 text-gray-600 dark:text-gray-500 text-xs">
 			{$i18n.t('Help us create the best community leaderboard by sharing your feedback history!')}
 		</div>
 

--- a/src/lib/components/admin/Evaluations/Leaderboard.svelte
+++ b/src/lib/components/admin/Evaluations/Leaderboard.svelte
@@ -396,7 +396,7 @@
 	{/if}
 </div>
 
-<div class=" text-gray-600 text-xs mt-1.5 w-full flex justify-end">
+<div class=" text-gray-600 dark:text-gray-500 text-xs mt-1.5 w-full flex justify-end">
 	<div class=" text-right">
 		<div class="line-clamp-1">
 			ⓘ {$i18n.t(

--- a/src/lib/components/admin/Functions.svelte
+++ b/src/lib/components/admin/Functions.svelte
@@ -250,7 +250,9 @@
 						</div>
 
 						<div class="flex gap-1.5 px-1">
-							<div class=" text-gray-600 text-xs font-medium flex-shrink-0">{func.id}</div>
+							<div class=" text-gray-600 dark:text-gray-500 text-xs font-medium flex-shrink-0">
+								{func.id}
+							</div>
 
 							<div class=" text-xs overflow-hidden text-ellipsis line-clamp-1">
 								{func.meta.description}
@@ -369,7 +371,7 @@
 	{/each}
 </div>
 
-<!-- <div class=" text-gray-600 text-xs mt-1 mb-2">
+<!-- <div class=" text-gray-600 dark:text-gray-500 text-xs mt-1 mb-2">
 	ⓘ {$i18n.t(
 		'Admins have access to all tools at all times; users need tools assigned per model in the workspace.'
 	)}
@@ -484,7 +486,7 @@
 		deleteHandler(selectedFunction);
 	}}
 >
-	<div class=" text-sm text-gray-600">
+	<div class=" text-sm text-gray-600 dark:text-gray-500">
 		{$i18n.t('This will delete')} <span class="  font-semibold">{selectedFunction.name}</span>.
 	</div>
 </DeleteConfirmDialog>
@@ -523,7 +525,7 @@
 		reader.readAsText(importFiles[0]);
 	}}
 >
-	<div class="text-sm text-gray-600">
+	<div class="text-sm text-gray-600 dark:text-gray-500">
 		<div class=" bg-yellow-500/20 text-yellow-700 dark:text-yellow-200 rounded-lg px-4 py-3">
 			<div>Please carefully review the following warnings:</div>
 

--- a/src/lib/components/admin/Functions/FunctionEditor.svelte
+++ b/src/lib/components/admin/Functions/FunctionEditor.svelte
@@ -411,7 +411,7 @@ class Pipe:
 		submitHandler();
 	}}
 >
-	<div class="text-sm text-gray-600">
+	<div class="text-sm text-gray-600 dark:text-gray-500">
 		<div class=" bg-yellow-500/20 text-yellow-700 dark:text-yellow-200 rounded-lg px-4 py-3">
 			<div>{$i18n.t('Please carefully review the following warnings:')}</div>
 

--- a/src/lib/components/admin/Settings.svelte
+++ b/src/lib/components/admin/Settings.svelte
@@ -47,7 +47,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 lg:flex-none flex text-right transition {selectedTab ===
 			'general'
 				? ''
-				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'general';
 			}}
@@ -73,7 +73,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-right transition {selectedTab ===
 			'connections'
 				? ''
-				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'connections';
 			}}
@@ -97,7 +97,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-right transition {selectedTab ===
 			'models'
 				? ''
-				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'models';
 			}}
@@ -123,7 +123,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-right transition {selectedTab ===
 			'evaluations'
 				? ''
-				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'evaluations';
 			}}
@@ -138,7 +138,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-right transition {selectedTab ===
 			'documents'
 				? ''
-				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'documents';
 			}}
@@ -168,7 +168,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-right transition {selectedTab ===
 			'web'
 				? ''
-				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'web';
 			}}
@@ -192,7 +192,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-right transition {selectedTab ===
 			'interface'
 				? ''
-				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'interface';
 			}}
@@ -218,7 +218,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-right transition {selectedTab ===
 			'audio'
 				? ''
-				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'audio';
 			}}
@@ -245,7 +245,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-right transition {selectedTab ===
 			'images'
 				? ''
-				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'images';
 			}}
@@ -271,7 +271,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-right transition {selectedTab ===
 			'pipelines'
 				? ''
-				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'pipelines';
 			}}
@@ -301,7 +301,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-right transition {selectedTab ===
 			'db'
 				? ''
-				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'db';
 			}}

--- a/src/lib/components/admin/Settings/Connections.svelte
+++ b/src/lib/components/admin/Settings/Connections.svelte
@@ -317,7 +317,7 @@
 						<div class="mt-1 text-xs text-gray-400 dark:text-gray-500">
 							{$i18n.t('Trouble accessing Ollama?')}
 							<a
-								class=" text-gray-600 font-medium underline"
+								class=" text-gray-600 dark:text-gray-500 font-medium underline"
 								href="https://github.com/open-webui/open-webui#troubleshooting"
 								target="_blank"
 							>

--- a/src/lib/components/admin/Settings/Connections/AddConnectionModal.svelte
+++ b/src/lib/components/admin/Settings/Connections/AddConnectionModal.svelte
@@ -146,7 +146,7 @@
 					<div class="px-1">
 						<div class="flex gap-2">
 							<div class="flex flex-col w-full">
-								<div class=" mb-0.5 text-xs text-gray-600">{$i18n.t('URL')}</div>
+								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('URL')}</div>
 
 								<div class="flex-1">
 									<input
@@ -192,7 +192,7 @@
 
 						<div class="flex gap-2 mt-2">
 							<div class="flex flex-col w-full">
-								<div class=" mb-0.5 text-xs text-gray-600">{$i18n.t('Key')}</div>
+								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Key')}</div>
 
 								<div class="flex-1">
 									<SensitiveInput
@@ -205,7 +205,9 @@
 							</div>
 
 							<div class="flex flex-col w-full">
-								<div class=" mb-1 text-xs text-gray-600">{$i18n.t('Prefix ID')}</div>
+								<div class=" mb-1 text-xs text-gray-600 dark:text-gray-500">
+									{$i18n.t('Prefix ID')}
+								</div>
 
 								<div class="flex-1">
 									<Tooltip
@@ -229,7 +231,7 @@
 
 						<div class="flex flex-col w-full">
 							<div class="mb-1 flex justify-between">
-								<div class="text-xs text-gray-600">{$i18n.t('Model IDs')}</div>
+								<div class="text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Model IDs')}</div>
 							</div>
 
 							{#if modelIds.length > 0}
@@ -253,7 +255,7 @@
 									{/each}
 								</div>
 							{:else}
-								<div class="text-gray-600 text-xs text-center py-2 px-10">
+								<div class="text-gray-600 dark:text-gray-500 text-xs text-center py-2 px-10">
 									{#if ollama}
 										{$i18n.t('Leave empty to include all models from "{{URL}}/api/tags" endpoint', {
 											URL: url
@@ -273,7 +275,7 @@
 							<input
 								class="w-full py-1 text-sm rounded-lg bg-transparent {modelId
 									? ''
-									: 'text-gray-600'} placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-none"
+									: 'text-gray-600 dark:text-gray-500 '} placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-none"
 								bind:value={modelId}
 								placeholder={$i18n.t('Add a model ID')}
 							/>

--- a/src/lib/components/admin/Settings/Connections/ManageOllamaModal.svelte
+++ b/src/lib/components/admin/Settings/Connections/ManageOllamaModal.svelte
@@ -831,7 +831,7 @@
 								<div class="flex justify-between items-center text-xs">
 									<div class=" text-sm font-medium">{$i18n.t('Experimental')}</div>
 									<button
-										class=" text-xs font-medium text-gray-600"
+										class=" text-xs font-medium text-gray-600 dark:text-gray-500"
 										type="button"
 										on:click={() => {
 											showExperimentalOllama = !showExperimentalOllama;

--- a/src/lib/components/admin/Settings/Evaluations.svelte
+++ b/src/lib/components/admin/Settings/Evaluations.svelte
@@ -130,7 +130,7 @@
 								/>
 							{/each}
 						{:else}
-							<div class=" text-center text-xs text-gray-600">
+							<div class=" text-center text-xs text-gray-600 dark:text-gray-500">
 								{$i18n.t(
 									`Using the default arena model with all models. Click the plus button to add custom models.`
 								)}

--- a/src/lib/components/admin/Settings/Evaluations/ArenaModelModal.svelte
+++ b/src/lib/components/admin/Settings/Evaluations/ArenaModelModal.svelte
@@ -226,7 +226,9 @@
 						</div>
 						<div class="flex gap-2">
 							<div class="flex flex-col w-full">
-								<div class=" mb-0.5 text-xs text-gray-600">{$i18n.t('Name')}</div>
+								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">
+									{$i18n.t('Name')}
+								</div>
 
 								<div class="flex-1">
 									<input
@@ -241,7 +243,7 @@
 							</div>
 
 							<div class="flex flex-col w-full">
-								<div class=" mb-0.5 text-xs text-gray-600">{$i18n.t('ID')}</div>
+								<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('ID')}</div>
 
 								<div class="flex-1">
 									<input
@@ -258,7 +260,9 @@
 						</div>
 
 						<div class="flex flex-col w-full mt-2">
-							<div class=" mb-1 text-xs text-gray-600">{$i18n.t('Description')}</div>
+							<div class=" mb-1 text-xs text-gray-600 dark:text-gray-500">
+								{$i18n.t('Description')}
+							</div>
 
 							<div class="flex-1">
 								<input
@@ -283,7 +287,7 @@
 
 						<div class="flex flex-col w-full">
 							<div class="mb-1 flex justify-between">
-								<div class="text-xs text-gray-600">{$i18n.t('Models')}</div>
+								<div class="text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Models')}</div>
 
 								<div>
 									<button
@@ -323,7 +327,7 @@
 									{/each}
 								</div>
 							{:else}
-								<div class="text-gray-600 text-xs text-center py-2">
+								<div class="text-gray-600 dark:text-gray-500 text-xs text-center py-2">
 									{$i18n.t('Leave empty to include all models or select specific models')}
 								</div>
 							{/if}

--- a/src/lib/components/admin/Settings/General.svelte
+++ b/src/lib/components/admin/Settings/General.svelte
@@ -145,7 +145,7 @@
 								<a
 									href="https://docs.openwebui.com/getting-started/advanced-topics/api-endpoints"
 									target="_blank"
-									class=" text-gray-600 font-medium underline"
+									class=" text-gray-600 dark:text-gray-500 font-medium underline"
 								>
 									{$i18n.t('To learn more about available endpoints, visit our documentation.')}
 								</a>
@@ -217,7 +217,7 @@
 
 					<div class="mt-2 text-xs text-gray-400 dark:text-gray-500">
 						{$i18n.t('Valid time units:')}
-						<span class=" text-gray-600 font-medium"
+						<span class=" text-gray-600 dark:text-gray-500 font-medium"
 							>{$i18n.t("'s', 'm', 'h', 'd', 'w' or '-1' for no expiration.")}</span
 						>
 					</div>
@@ -391,7 +391,7 @@
 						</div>
 						<div class="text-xs text-gray-400 dark:text-gray-500">
 							<a
-								class=" text-gray-600 font-medium underline"
+								class=" text-gray-600 dark:text-gray-500 font-medium underline"
 								href="https://ldap.com/ldap-filters/"
 								target="_blank"
 							>

--- a/src/lib/components/admin/Settings/Models.svelte
+++ b/src/lib/components/admin/Settings/Models.svelte
@@ -208,7 +208,11 @@
 								</div>
 							</div>
 
-							<div class=" flex-1 self-center {(model?.is_active ?? true) ? '' : 'text-gray-600'}">
+							<div
+								class=" flex-1 self-center {(model?.is_active ?? true)
+									? ''
+									: 'text-gray-600 dark:text-gray-500'}"
+							>
 								<Tooltip
 									content={marked.parse(
 										!!model?.meta?.description
@@ -222,7 +226,9 @@
 								>
 									<div class="  font-semibold line-clamp-1">{model.name}</div>
 								</Tooltip>
-								<div class=" text-xs overflow-hidden text-ellipsis line-clamp-1 text-gray-600">
+								<div
+									class=" text-xs overflow-hidden text-ellipsis line-clamp-1 text-gray-600 dark:text-gray-500"
+								>
 									<span class=" line-clamp-1">
 										{!!model?.meta?.description
 											? model?.meta?.description

--- a/src/lib/components/admin/Settings/Models/ConfigureModelsModal.svelte
+++ b/src/lib/components/admin/Settings/Models/ConfigureModelsModal.svelte
@@ -130,7 +130,9 @@
 						<div>
 							<div class="flex flex-col w-full">
 								<div class="mb-1 flex justify-between">
-									<div class="text-xs text-gray-600">{$i18n.t('Reorder Models')}</div>
+									<div class="text-xs text-gray-600 dark:text-gray-500">
+										{$i18n.t('Reorder Models')}
+									</div>
 								</div>
 
 								<ModelList bind:modelIds />
@@ -142,7 +144,9 @@
 						<div>
 							<div class="flex flex-col w-full">
 								<div class="mb-1 flex justify-between">
-									<div class="text-xs text-gray-600">{$i18n.t('Default Models')}</div>
+									<div class="text-xs text-gray-600 dark:text-gray-500">
+										{$i18n.t('Default Models')}
+									</div>
 								</div>
 
 								{#if defaultModelIds.length > 0}
@@ -168,7 +172,7 @@
 										{/each}
 									</div>
 								{:else}
-									<div class="text-gray-600 text-xs text-center py-2">
+									<div class="text-gray-600 dark:text-gray-500 text-xs text-center py-2">
 										{$i18n.t('No models selected')}
 									</div>
 								{/if}

--- a/src/lib/components/admin/Settings/Models/ModelList.svelte
+++ b/src/lib/components/admin/Settings/Models/ModelList.svelte
@@ -52,7 +52,7 @@
 		{/each}
 	</div>
 {:else}
-	<div class="text-gray-600 text-xs text-center py-2">
+	<div class="text-gray-600 dark:text-gray-500 text-xs text-center py-2">
 		{$i18n.t('No models found')}
 	</div>
 {/if}

--- a/src/lib/components/admin/Users.svelte
+++ b/src/lib/components/admin/Users.svelte
@@ -55,7 +55,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg lg:flex-none flex text-right transition {selectedTab ===
 			'overview'
 				? ''
-				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'overview';
 			}}
@@ -79,7 +79,7 @@
 			class="px-0.5 py-1 min-w-fit rounded-lg lg:flex-none flex text-right transition {selectedTab ===
 			'groups'
 				? ''
-				: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+				: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 			on:click={() => {
 				selectedTab = 'groups';
 			}}

--- a/src/lib/components/admin/Users/Groups/Display.svelte
+++ b/src/lib/components/admin/Users/Groups/Display.svelte
@@ -12,7 +12,7 @@
 
 <div class="flex gap-2">
 	<div class="flex flex-col w-full">
-		<div class=" mb-0.5 text-xs text-gray-600">{$i18n.t('Name')}</div>
+		<div class=" mb-0.5 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Name')}</div>
 
 		<div class="flex-1">
 			<input
@@ -28,12 +28,12 @@
 </div>
 
 <!-- <div class="flex flex-col w-full mt-2">
-	<div class=" mb-1 text-xs text-gray-600">{$i18n.t('Color')}</div>
+	<div class=" mb-1 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Color')}</div>
 
 	<div class="flex-1">
 		<Tooltip content={$i18n.t('Hex Color - Leave empty for default color')} placement="top-start">
 			<div class="flex gap-0.5">
-				<div class="text-gray-600">#</div>
+				<div class="text-gray-600 dark:text-gray-500">#</div>
 
 				<input
 					class="w-full text-sm bg-transparent placeholder:text-gray-300 dark:placeholder:text-gray-700 outline-none"
@@ -48,7 +48,7 @@
 </div> -->
 
 <div class="flex flex-col w-full mt-2">
-	<div class=" mb-1 text-xs text-gray-600">{$i18n.t('Description')}</div>
+	<div class=" mb-1 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Description')}</div>
 
 	<div class="flex-1">
 		<Textarea

--- a/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
+++ b/src/lib/components/admin/Users/Groups/EditGroupModal.svelte
@@ -131,7 +131,7 @@
 									class="px-0.5 py-1 max-w-fit w-fit rounded-lg flex-1 lg:flex-none flex text-right transition {selectedTab ===
 									'general'
 										? ''
-										: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+										: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 									on:click={() => {
 										selectedTab = 'general';
 									}}
@@ -160,7 +160,7 @@
 									class="px-0.5 py-1 max-w-fit w-fit rounded-lg flex-1 lg:flex-none flex text-right transition {selectedTab ===
 									'permissions'
 										? ''
-										: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+										: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 									on:click={() => {
 										selectedTab = 'permissions';
 									}}
@@ -178,7 +178,7 @@
 									class="px-0.5 py-1 max-w-fit w-fit rounded-lg flex-1 lg:flex-none flex text-right transition {selectedTab ===
 									'users'
 										? ''
-										: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+										: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 									on:click={() => {
 										selectedTab = 'users';
 									}}
@@ -213,7 +213,7 @@
 								class="px-0.5 pb-1.5 min-w-fit flex text-right transition border-b-2 {selectedTab ===
 								'display'
 									? ' dark:border-white'
-									: 'border-transparent text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									: 'border-transparent text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 								on:click={() => {
 									selectedTab = 'display';
 								}}
@@ -228,7 +228,7 @@
 								class="px-0.5 pb-1.5 min-w-fit flex text-right transition border-b-2 {selectedTab ===
 								'permissions'
 									? '  dark:border-white'
-									: 'border-transparent text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									: 'border-transparent text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 								on:click={() => {
 									selectedTab = 'permissions';
 								}}
@@ -243,7 +243,7 @@
 								class="px-0.5 pb-1.5 min-w-fit flex text-right transition border-b-2 {selectedTab ===
 								'users'
 									? ' dark:border-white'
-									: ' border-transparent text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									: ' border-transparent text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 								on:click={() => {
 									selectedTab = 'users';
 								}}

--- a/src/lib/components/admin/Users/Groups/Permissions.svelte
+++ b/src/lib/components/admin/Users/Groups/Permissions.svelte
@@ -38,7 +38,7 @@
 				<div class=" space-y-1.5">
 					<div class="flex flex-col w-full">
 						<div class="mb-1 flex justify-between">
-							<div class="text-xs text-gray-600">{$i18n.t('Model IDs')}</div>
+							<div class="text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Model IDs')}</div>
 						</div>
 
 						{#if model_ids.length > 0}
@@ -62,7 +62,7 @@
 								{/each}
 							</div>
 						{:else}
-							<div class="text-gray-600 text-xs text-center py-2 px-10">
+							<div class="text-gray-600 dark:text-gray-500 text-xs text-center py-2 px-10">
 								{$i18n.t('No model IDs')}
 							</div>
 						{/if}

--- a/src/lib/components/admin/Users/Groups/Users.svelte
+++ b/src/lib/components/admin/Users/Groups/Users.svelte
@@ -123,7 +123,7 @@
 					</div>
 				{/each}
 			{:else}
-				<div class="text-gray-600 text-xs text-center py-2 px-10">
+				<div class="text-gray-600 dark:text-gray-500 text-xs text-center py-2 px-10">
 					{$i18n.t('No users were found.')}
 				</div>
 			{/if}

--- a/src/lib/components/admin/Users/UserList.svelte
+++ b/src/lib/components/admin/Users/UserList.svelte
@@ -461,7 +461,7 @@
 	</table>
 </div>
 
-<div class=" text-gray-600 text-xs mt-1.5 text-right">
+<div class=" text-gray-600 dark:text-gray-500 text-xs mt-1.5 text-right">
 	ⓘ {$i18n.t("Click on the user role button to change a user's role.")}
 </div>
 

--- a/src/lib/components/admin/Users/UserList/AddUserModal.svelte
+++ b/src/lib/components/admin/Users/UserList/AddUserModal.svelte
@@ -255,7 +255,7 @@
 										'Ensure your CSV file includes 4 columns in this order: Name, Email, Password, Role.'
 									)}
 									<a
-										class="underline dark:text-gray-700"
+										class="underline dark:text-gray-500"
 										href="{WEBUI_BASE_URL}/static/user-import.csv"
 									>
 										{$i18n.t('Click here to download user import template file.')}

--- a/src/lib/components/admin/Users/UserList/EditUserModal.svelte
+++ b/src/lib/components/admin/Users/UserList/EditUserModal.svelte
@@ -70,7 +70,7 @@
 						<div>
 							<div class=" self-center capitalize font-semibold">{selectedUser.name}</div>
 
-							<div class="text-xs text-gray-600">
+							<div class="text-xs text-gray-600 dark:text-gray-500">
 								{$i18n.t('Created at')}
 								{dayjs(selectedUser.created_at * 1000).format($i18n.t('MMMM DD, YYYY'))}
 							</div>
@@ -81,7 +81,7 @@
 
 					<div class=" flex flex-col space-y-1.5">
 						<div class="flex flex-col w-full">
-							<div class=" mb-1 text-xs text-gray-600">{$i18n.t('Email')}</div>
+							<div class=" mb-1 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Email')}</div>
 
 							<div class="flex-1">
 								<input
@@ -96,7 +96,7 @@
 						</div>
 
 						<div class="flex flex-col w-full">
-							<div class=" mb-1 text-xs text-gray-600">{$i18n.t('Name')}</div>
+							<div class=" mb-1 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('Name')}</div>
 
 							<div class="flex-1">
 								<input
@@ -110,7 +110,9 @@
 						</div>
 
 						<div class="flex flex-col w-full">
-							<div class=" mb-1 text-xs text-gray-600">{$i18n.t('New Password')}</div>
+							<div class=" mb-1 text-xs text-gray-600 dark:text-gray-500">
+								{$i18n.t('New Password')}
+							</div>
 
 							<div class="flex-1">
 								<input

--- a/src/lib/components/channel/Messages.svelte
+++ b/src/lib/components/channel/Messages.svelte
@@ -72,7 +72,7 @@
 					<div class="flex flex-col gap-1.5 pb-5 pt-10">
 						<div class="text-2xl font-medium capitalize">{channel.name}</div>
 
-						<div class=" text-gray-600">
+						<div class=" text-gray-600 dark:text-gray-500">
 							This channel was created on {dayjs(channel.created_at / 1000000).format(
 								'MMMM D, YYYY'
 							)}. This is the very beginning of the {channel.name}

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2069,7 +2069,7 @@
 					{/if}
 					{#if $config?.features?.enable_disclaimer}
 						<div
-							class="absolute bottom-1.5 text-xs text-gray-600 text-center line-clamp-1 right-14 left-3"
+							class="absolute bottom-1.5 text-xs text-gray-600 dark:text-gray-500 text-center line-clamp-1 right-14 left-3"
 						>
 							{$i18n.t('GSA Chat can make mistakes. Review all responses for accuracy.')}
 						</div>

--- a/src/lib/components/chat/MessageInput/Commands/Knowledge.svelte
+++ b/src/lib/components/chat/MessageInput/Commands/Knowledge.svelte
@@ -256,7 +256,7 @@
 										</button>
 									{/each}
 								{:else}
-									<div class=" text-gray-600 text-xs mt-1 mb-2">
+									<div class=" text-gray-600 dark:text-gray-500 text-xs mt-1 mb-2">
 										{$i18n.t('No files found.')}
 									</div>
 								{/if}

--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -251,7 +251,7 @@
 					childrenIds: [],
 					files: undefined,
 					content: content,
-					timestamp: Math.floor(Date.now() / 1000) // Unix epoch
+					timestamp: Date.now() // Unix epoch
 				};
 
 				history.messages[responseMessageId] = responseMessage;

--- a/src/lib/components/chat/Messages/CodeBlock.svelte
+++ b/src/lib/components/chat/Messages/CodeBlock.svelte
@@ -381,12 +381,12 @@ __builtins__.input = input`);
 
 			{#if executing}
 				<div class="bg-[#202123] text-white px-4 py-4 rounded-b-lg">
-					<div class=" text-gray-600 text-xs mb-1">STDOUT/STDERR</div>
+					<div class=" text-gray-600 dark:text-gray-500 text-xs mb-1">STDOUT/STDERR</div>
 					<div class="text-sm">Running...</div>
 				</div>
 			{:else if stdout || stderr || result}
 				<div class="bg-[#202123] text-white px-4 py-4 rounded-b-lg">
-					<div class=" text-gray-600 text-xs mb-1">STDOUT/STDERR</div>
+					<div class=" text-gray-600 dark:text-gray-500 text-xs mb-1">STDOUT/STDERR</div>
 					<div class="text-sm">{stdout || stderr || result}</div>
 				</div>
 			{/if}

--- a/src/lib/components/chat/Messages/CodeExecutionModal.svelte
+++ b/src/lib/components/chat/Messages/CodeExecutionModal.svelte
@@ -69,13 +69,15 @@
 					<div class="dark:bg-[#202123] dark:text-white px-4 py-4 rounded-b-lg flex flex-col gap-3">
 						{#if codeExecution?.result?.error}
 							<div>
-								<div class=" text-gray-600 text-xs mb-1">{$i18n.t('ERROR')}</div>
+								<div class=" text-gray-600 dark:text-gray-500 text-xs mb-1">{$i18n.t('ERROR')}</div>
 								<div class="text-sm">{codeExecution?.result?.error}</div>
 							</div>
 						{/if}
 						{#if codeExecution?.result?.output}
 							<div>
-								<div class=" text-gray-600 text-xs mb-1">{$i18n.t('OUTPUT')}</div>
+								<div class=" text-gray-600 dark:text-gray-500 text-xs mb-1">
+									{$i18n.t('OUTPUT')}
+								</div>
 								<div class="text-sm">{codeExecution?.result?.output}</div>
 							</div>
 						{/if}

--- a/src/lib/components/chat/Messages/MultiResponseMessages.svelte
+++ b/src/lib/components/chat/Messages/MultiResponseMessages.svelte
@@ -264,7 +264,7 @@
 										<span
 											class=" self-center invisible group-hover:visible text-gray-400 text-xs font-medium uppercase ml-0.5 -mt-0.5"
 										>
-											{dayjs(message.timestamp * 1000).format($i18n.t('h:mm a'))}
+											{dayjs(message.timestamp).format($i18n.t('h:mm a'))} TS
 										</span>
 									{/if}
 								</Name>

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -506,7 +506,7 @@
 					<span
 						class=" self-center invisible group-hover:visible text-gray-400 text-xs font-medium uppercase ml-0.5 -mt-0.5"
 					>
-						{dayjs(message.timestamp * 1000).format($i18n.t('h:mm a'))}
+						{dayjs(message.timestamp).format($i18n.t('h:mm a'))}
 					</span>
 				{/if}
 			</Name>

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -112,7 +112,7 @@
 						<span
 							class=" invisible group-hover:visible text-gray-400 text-xs font-medium uppercase ml-0.5 -mt-0.5"
 						>
-							{dayjs(message.timestamp * 1000).format($i18n.t('h:mm a'))}
+							{dayjs(message.timestamp).format($i18n.t('h:mm a'))}
 						</span>
 					{/if}
 				</Name>

--- a/src/lib/components/chat/ModelSelector.svelte
+++ b/src/lib/components/chat/ModelSelector.svelte
@@ -115,7 +115,9 @@
 </div>
 
 {#if showSetDefault && $config?.features?.enable_set_as_default_model}
-	<div class=" absolute text-left mt-[1px] ml-1 text-[0.7rem] text-gray-600 font-primary">
+	<div
+		class=" absolute text-left mt-[1px] ml-1 text-[0.7rem] text-gray-600 dark:text-gray-500 font-primary"
+	>
 		<button on:click={saveDefaultModel}> {$i18n.t('Set as default')}</button>
 	</div>
 {/if}

--- a/src/lib/components/chat/Placeholder.svelte
+++ b/src/lib/components/chat/Placeholder.svelte
@@ -141,7 +141,6 @@
 					{$i18n.t('How can I help you today?')}
 				</h1>
 			</div>
-		
 
 			<div
 				class="text-base font-normal xl:translate-x-6 md:max-w-3xl w-full py-3 {atSelectedModel

--- a/src/lib/components/chat/Placeholder.svelte
+++ b/src/lib/components/chat/Placeholder.svelte
@@ -103,7 +103,7 @@
 		class="w-full text-gray-800 dark:text-gray-100 font-medium text-center flex items-center gap-4 font-primary"
 	>
 		<div class="w-full flex flex-col justify-center items-center">
-			<div class="flex flex-row justify-center gap-3 sm:gap-3.5 w-fit px-5">
+			<div class="flex flex-row justify-center gap-3 sm:gap-3.5 w-fit px-5 mb-3">
 				{#if $config?.features?.enable_message_input_logo}
 					<div class="flex flex-shrink-0 justify-center">
 						<div class="flex -space-x-4 mb-0.5" in:fade={{ duration: 100 }}>
@@ -141,45 +141,7 @@
 					{$i18n.t('How can I help you today?')}
 				</h1>
 			</div>
-
-			<div class="flex mt-1 mb-2">
-				<div in:fade={{ duration: 100, delay: 50 }}>
-					{#if models[selectedModelIdx]?.info?.meta?.description ?? null}
-						<Tooltip
-							className=" w-fit"
-							content={marked.parse(
-								sanitizeResponseContent(models[selectedModelIdx]?.info?.meta?.description ?? '')
-							)}
-							placement="top"
-						>
-							<div
-								class="mt-0.5 px-2 text-sm font-normal text-gray-600 dark:text-gray-400 line-clamp-2 max-w-xl markdown"
-							>
-								{@html marked.parse(
-									sanitizeResponseContent(models[selectedModelIdx]?.info?.meta?.description)
-								)}
-							</div>
-						</Tooltip>
-
-						{#if models[selectedModelIdx]?.info?.meta?.user}
-							<div class="mt-0.5 text-sm font-normal text-gray-400 dark:text-gray-500">
-								By
-								{#if models[selectedModelIdx]?.info?.meta?.user.community}
-									<a
-										href="https://openwebui.com/m/{models[selectedModelIdx]?.info?.meta?.user
-											.username}"
-										>{models[selectedModelIdx]?.info?.meta?.user.name
-											? models[selectedModelIdx]?.info?.meta?.user.name
-											: `@${models[selectedModelIdx]?.info?.meta?.user.username}`}</a
-									>
-								{:else}
-									{models[selectedModelIdx]?.info?.meta?.user.name}
-								{/if}
-							</div>
-						{/if}
-					{/if}
-				</div>
-			</div>
+		
 
 			<div
 				class="text-base font-normal xl:translate-x-6 md:max-w-3xl w-full py-3 {atSelectedModel

--- a/src/lib/components/chat/Settings/Account/UpdatePassword.svelte
+++ b/src/lib/components/chat/Settings/Account/UpdatePassword.svelte
@@ -56,7 +56,9 @@
 	{#if show}
 		<div class=" py-2.5 space-y-1.5">
 			<div class="flex flex-col w-full">
-				<div class=" mb-1 text-xs text-gray-600">{$i18n.t('Current Password')}</div>
+				<div class=" mb-1 text-xs text-gray-600 dark:text-gray-500">
+					{$i18n.t('Current Password')}
+				</div>
 
 				<div class="flex-1">
 					<input
@@ -71,7 +73,7 @@
 			</div>
 
 			<div class="flex flex-col w-full">
-				<div class=" mb-1 text-xs text-gray-600">{$i18n.t('New Password')}</div>
+				<div class=" mb-1 text-xs text-gray-600 dark:text-gray-500">{$i18n.t('New Password')}</div>
 
 				<div class="flex-1">
 					<input
@@ -86,7 +88,9 @@
 			</div>
 
 			<div class="flex flex-col w-full">
-				<div class=" mb-1 text-xs text-gray-600">{$i18n.t('Confirm Password')}</div>
+				<div class=" mb-1 text-xs text-gray-600 dark:text-gray-500">
+					{$i18n.t('Confirm Password')}
+				</div>
 
 				<div class="flex-1">
 					<input

--- a/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
+++ b/src/lib/components/chat/Settings/Advanced/AdvancedParams.svelte
@@ -975,7 +975,7 @@
 
 			{#if (params?.use_mmap ?? null) !== null}
 				<div class="flex justify-between items-center mt-1">
-					<div class="text-xs text-gray-600">
+					<div class="text-xs text-gray-600 dark:text-gray-500">
 						{params.use_mmap ? 'Enabled' : 'Disabled'}
 					</div>
 					<div class=" pr-2">
@@ -1016,7 +1016,7 @@
 
 			{#if (params?.use_mlock ?? null) !== null}
 				<div class="flex justify-between items-center mt-1">
-					<div class="text-xs text-gray-600">
+					<div class="text-xs text-gray-600 dark:text-gray-500">
 						{params.use_mlock ? 'Enabled' : 'Disabled'}
 					</div>
 

--- a/src/lib/components/chat/Settings/Personalization.svelte
+++ b/src/lib/components/chat/Settings/Personalization.svelte
@@ -42,7 +42,9 @@
 					<div class="text-sm font-medium">
 						{$i18n.t('Memory')}
 
-						<span class=" text-xs text-gray-600">({$i18n.t('Experimental')})</span>
+						<span class=" text-xs text-gray-600 dark:text-gray-500"
+							>({$i18n.t('Experimental')})</span
+						>
 					</div>
 				</Tooltip>
 

--- a/src/lib/components/chat/Settings/Personalization/AddMemoryModal.svelte
+++ b/src/lib/components/chat/Settings/Personalization/AddMemoryModal.svelte
@@ -77,7 +77,7 @@
 							placeholder={$i18n.t('Enter a detail about yourself for your LLMs to recall')}
 						/>
 
-						<div class="text-xs text-gray-600">
+						<div class="text-xs text-gray-600 dark:text-gray-500">
 							ⓘ {$i18n.t('Refer to yourself as "User" (e.g., "User is learning Spanish")')}
 						</div>
 					</div>

--- a/src/lib/components/chat/Settings/Personalization/EditMemoryModal.svelte
+++ b/src/lib/components/chat/Settings/Personalization/EditMemoryModal.svelte
@@ -87,7 +87,7 @@
 							placeholder={$i18n.t('Enter a detail about yourself for your LLMs to recall')}
 						/>
 
-						<div class="text-xs text-gray-600">
+						<div class="text-xs text-gray-600 dark:text-gray-500">
 							ⓘ {$i18n.t('Refer to yourself as "User" (e.g., "User is learning Spanish")')}
 						</div>
 					</div>

--- a/src/lib/components/chat/Settings/Personalization/ManageModal.svelte
+++ b/src/lib/components/chat/Settings/Personalization/ManageModal.svelte
@@ -145,7 +145,7 @@
 					</div>
 				{:else}
 					<div class="text-center flex h-full text-sm w-full">
-						<div class=" my-auto pb-10 px-4 w-full text-gray-600">
+						<div class=" my-auto pb-10 px-4 w-full text-gray-600 dark:text-gray-500">
 							{$i18n.t('Memories accessible by LLMs will be shown here.')}
 						</div>
 					</div>

--- a/src/lib/components/chat/SettingsModal.svelte
+++ b/src/lib/components/chat/SettingsModal.svelte
@@ -384,7 +384,7 @@
 								class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-left transition {selectedTab ===
 								'general'
 									? ''
-									: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 								on:click={() => {
 									selectedTab = 'general';
 								}}
@@ -410,7 +410,7 @@
 								class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-left transition {selectedTab ===
 								'interface'
 									? ''
-									: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 								on:click={() => {
 									selectedTab = 'interface';
 								}}
@@ -436,7 +436,7 @@
 								class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-left transition {selectedTab ===
 								'personalization'
 									? ''
-									: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 								on:click={() => {
 									selectedTab = 'personalization';
 								}}
@@ -451,7 +451,7 @@
 								class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-left transition {selectedTab ===
 								'audio'
 									? ''
-									: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 								on:click={() => {
 									selectedTab = 'audio';
 								}}
@@ -478,7 +478,7 @@
 								class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-left transition {selectedTab ===
 								'chats'
 									? ''
-									: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 								on:click={() => {
 									selectedTab = 'chats';
 								}}
@@ -504,7 +504,7 @@
 								class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-left transition {selectedTab ===
 								'account'
 									? ''
-									: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 								on:click={() => {
 									selectedTab = 'account';
 								}}
@@ -530,7 +530,7 @@
 								class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-left transition {selectedTab ===
 								'about'
 									? ''
-									: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+									: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 								on:click={() => {
 									selectedTab = 'about';
 								}}
@@ -557,7 +557,7 @@
 									class="px-0.5 py-1 min-w-fit rounded-lg flex-1 md:flex-none flex text-left transition {selectedTab ===
 									'admin'
 										? ''
-										: ' text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'}"
+										: ' text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'}"
 									on:click={async () => {
 										await goto('/admin/settings');
 										show = false;

--- a/src/lib/components/chat/Suggestions.svelte
+++ b/src/lib/components/chat/Suggestions.svelte
@@ -35,7 +35,7 @@
 			<div>
 				{#if prompt.title && prompt.title[0] !== ''}
 					<div
-						class="px-2 py-2 border border-gray-400 text-sm items-center text-gray-400 dark:text-gray-600 bg-transparent rounded-full hover:text-gray-800 hover:border-gray-800 dark:text-gray-300 dark:border-gray-600 dark:hover:border-gray-100 dark:hover:text-gray-100 truncate text-overflow:ellipsis"
+						class="px-2 py-2 border border-gray-400 text-sm items-center text-gray-400 dark:text-gray-500 bg-transparent rounded-full hover:text-gray-800 hover:border-gray-800 dark:text-gray-300 dark:border-gray-600 dark:hover:border-gray-100 dark:hover:text-gray-100 truncate text-overflow:ellipsis"
 					>
 						{prompt.title[0]}
 					</div>

--- a/src/lib/components/common/FileItem.svelte
+++ b/src/lib/components/common/FileItem.svelte
@@ -83,7 +83,7 @@
 				{name}
 			</div>
 
-			<div class=" flex justify-between text-gray-600 text-xs line-clamp-1">
+			<div class=" flex justify-between text-gray-600 dark:text-gray-500 text-xs line-clamp-1">
 				{#if type === 'file'}
 					{$i18n.t('File')}
 				{:else if type === 'doc'}
@@ -108,7 +108,9 @@
 						</div>
 					{/if}
 					<div class="font-medium line-clamp-1 flex-1">{name}</div>
-					<div class="text-gray-600 text-xs capitalize shrink-0">{formatFileSize(size)}</div>
+					<div class="text-gray-600 dark:text-gray-500 text-xs capitalize shrink-0">
+						{formatFileSize(size)}
+					</div>
 				</div>
 			</div>
 		</Tooltip>

--- a/src/lib/components/common/FileItemModal.svelte
+++ b/src/lib/components/common/FileItemModal.svelte
@@ -55,7 +55,7 @@
 
 			<div>
 				<div class="flex flex-col items-center md:flex-row gap-1 justify-between w-full">
-					<div class=" flex flex-wrap text-sm gap-1 text-gray-600">
+					<div class=" flex flex-wrap text-sm gap-1 text-gray-600 dark:text-gray-500">
 						{#if item.size}
 							<div class="capitalize shrink-0">{formatFileSize(item.size)}</div>
 							•

--- a/src/lib/components/common/Folder.svelte
+++ b/src/lib/components/common/Folder.svelte
@@ -130,7 +130,7 @@
 				class="w-full group rounded-md relative flex items-center justify-between hover:bg-gray-100 dark:hover:bg-gray-900 text-gray-600 dark:text-gray-500 transition"
 			>
 				<button class="w-full py-1.5 pl-2 flex items-center gap-1.5 text-xs font-medium">
-					<div class="text-gray-600 dark:text-gray-600">
+					<div class="text-gray-600 dark:text-gray-500">
 						{#if open}
 							<ChevronDown className=" size-3" strokeWidth="2.5" />
 						{:else}

--- a/src/lib/components/common/Switch.svelte
+++ b/src/lib/components/common/Switch.svelte
@@ -10,9 +10,9 @@
 
 <Switch.Root
 	bind:checked={state}
-	class="flex h-5 min-h-5 w-9 shrink-0 cursor-pointer items-center rounded-full px-[3px] mx-[1px] transition  {state
+	class="flex h-5 min-h-5 w-9 shrink-0 cursor-pointer items-center rounded-full px-[3px] mx-[4px] transition  {state
 		? ' bg-emerald-600'
-		: 'bg-gray-200 dark:bg-transparent'} outline outline-1 outline-gray-100 dark:outline-gray-800"
+		: 'bg-gray-550 dark:bg-transparent'} outline outline-1 focus:outline-2 outline-gsa-blue outline-gray-500 dark:outline-gray-500"
 >
 	<Switch.Thumb
 		class="pointer-events-none block size-4 shrink-0 rounded-full bg-white transition-transform data-[state=checked]:translate-x-3.5 data-[state=unchecked]:translate-x-0 data-[state=unchecked]:shadow-mini "

--- a/src/lib/components/common/Valves.svelte
+++ b/src/lib/components/common/Valves.svelte
@@ -17,7 +17,7 @@
 					{valvesSpec.properties[property].title}
 
 					{#if (valvesSpec?.required ?? []).includes(property)}
-						<span class=" text-gray-600">*required</span>
+						<span class=" text-gray-600 dark:text-gray-500">*required</span>
 					{/if}
 				</div>
 
@@ -67,7 +67,7 @@
 							</select>
 						{:else if (valvesSpec.properties[property]?.type ?? null) === 'boolean'}
 							<div class="flex justify-between items-center">
-								<div class="text-xs text-gray-600">
+								<div class="text-xs text-gray-600 dark:text-gray-500">
 									{valves[property] ? 'Enabled' : 'Disabled'}
 								</div>
 
@@ -98,7 +98,7 @@
 			{/if}
 
 			{#if (valvesSpec.properties[property]?.description ?? null) !== null}
-				<div class="text-xs text-gray-600">
+				<div class="text-xs text-gray-600 dark:text-gray-500">
 					{valvesSpec.properties[property].description}
 				</div>
 			{/if}

--- a/src/lib/components/layout/Sidebar/ChannelModal.svelte
+++ b/src/lib/components/layout/Sidebar/ChannelModal.svelte
@@ -91,7 +91,9 @@
 					}}
 				>
 					<div class="flex flex-col w-full mt-2">
-						<div class=" mb-1 text-xs text-gray-600">{$i18n.t('Channel Name')}</div>
+						<div class=" mb-1 text-xs text-gray-600 dark:text-gray-500">
+							{$i18n.t('Channel Name')}
+						</div>
 
 						<div class="flex-1">
 							<input

--- a/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
+++ b/src/lib/components/layout/Sidebar/RecursiveFolder.svelte
@@ -380,7 +380,7 @@
 					editHandler();
 				}}
 			>
-				<div class="text-gray-600 dark:text-gray-600">
+				<div class="text-gray-600 dark:text-gray-500">
 					{#if open}
 						<ChevronDown className=" size-3" strokeWidth="2.5" />
 					{:else}

--- a/src/lib/components/workspace/Knowledge.svelte
+++ b/src/lib/components/workspace/Knowledge.svelte
@@ -163,7 +163,7 @@
 						</div>
 
 						<div class="mt-3 flex justify-between">
-							<div class="text-xs text-gray-600">
+							<div class="text-xs text-gray-600 dark:text-gray-500">
 								<Tooltip
 									content={item?.user?.email ?? $i18n.t('Deleted User')}
 									className="flex shrink-0"
@@ -187,7 +187,7 @@
 		{/each}
 	</div>
 
-	<div class=" text-gray-600 text-xs mt-1 mb-2">
+	<div class=" text-gray-600 dark:text-gray-500 text-xs mt-1 mb-2">
 		ⓘ {$i18n.t("Use '#' in the prompt input to load and include your knowledge.")}
 	</div>
 {:else}

--- a/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
+++ b/src/lib/components/workspace/Knowledge/KnowledgeBase.svelte
@@ -721,7 +721,7 @@
 						</div>
 					{:else}
 						<div class="h-full flex w-full">
-							<div class="m-auto text-xs text-center text-gray-200 dark:text-gray-700">
+							<div class="m-auto text-xs text-center text-gray-200 dark:text-gray-500">
 								{$i18n.t('Drag and drop a file to upload or select a file to view')}
 							</div>
 						</div>
@@ -855,7 +855,9 @@
 								/>
 							</div>
 						{:else}
-							<div class="my-3 flex flex-col justify-center text-center text-gray-600 text-xs">
+							<div
+								class="my-3 flex flex-col justify-center text-center text-gray-600 dark:text-gray-500 text-xs"
+							>
 								<div>
 									{$i18n.t('No content found')}
 								</div>

--- a/src/lib/components/workspace/Models.svelte
+++ b/src/lib/components/workspace/Models.svelte
@@ -255,7 +255,11 @@
 						class=" flex flex-1 cursor-pointer w-full"
 						href={`/?models=${encodeURIComponent(model.id)}`}
 					>
-						<div class=" flex-1 self-center {model.is_active ? '' : 'text-gray-600'}">
+						<div
+							class=" flex-1 self-center {model.is_active
+								? ''
+								: 'text-gray-600 dark:text-gray-500'}"
+						>
 							<Tooltip
 								content={marked.parse(model?.meta?.description ?? model.id)}
 								className=" w-fit"
@@ -284,7 +288,7 @@
 							className="flex shrink-0"
 							placement="top-start"
 						>
-							<div class="shrink-0 text-gray-600">
+							<div class="shrink-0 text-gray-600 dark:text-gray-500">
 								{$i18n.t('By {{name}}', {
 									name: capitalizeFirstLetter(
 										model?.user?.name ?? model?.user?.email ?? $i18n.t('Deleted User')

--- a/src/lib/components/workspace/Models/ModelEditor.svelte
+++ b/src/lib/components/workspace/Models/ModelEditor.svelte
@@ -443,7 +443,7 @@
 						<div class="flex-1">
 							<div>
 								<input
-									class="text-xs w-full bg-transparent text-gray-600 outline-none"
+									class="text-xs w-full bg-transparent text-gray-600 dark:text-gray-500 outline-none"
 									placeholder={$i18n.t('Model ID')}
 									bind:value={id}
 									disabled={edit}
@@ -715,7 +715,7 @@
 						<Capabilities bind:capabilities />
 					</div>
 
-					<div class="my-2 text-gray-600 dark:text-gray-700">
+					<div class="my-2 text-gray-600 dark:text-gray-500">
 						<div class="flex w-full justify-between mb-2">
 							<div class=" self-center text-sm font-semibold">{$i18n.t('JSON Preview')}</div>
 

--- a/src/lib/components/workspace/Prompts.svelte
+++ b/src/lib/components/workspace/Prompts.svelte
@@ -100,7 +100,7 @@
 			deleteHandler(deletePrompt);
 		}}
 	>
-		<div class=" text-sm text-gray-600">
+		<div class=" text-sm text-gray-600 dark:text-gray-500">
 			{$i18n.t('This will delete')} <span class="  font-semibold">{deletePrompt.command}</span>.
 		</div>
 	</DeleteConfirmDialog>
@@ -159,7 +159,7 @@
 								className="flex shrink-0"
 								placement="top-start"
 							>
-								<div class="shrink-0 text-gray-600">
+								<div class="shrink-0 text-gray-600 dark:text-gray-500">
 									{$i18n.t('By {{name}}', {
 										name: capitalizeFirstLetter(
 											prompt?.user?.name ?? prompt?.user?.email ?? $i18n.t('Deleted User')

--- a/src/lib/components/workspace/Prompts/PromptEditor.svelte
+++ b/src/lib/components/workspace/Prompts/PromptEditor.svelte
@@ -113,7 +113,7 @@
 						</div>
 					</div>
 
-					<div class="flex gap-0.5 items-center text-xs text-gray-600">
+					<div class="flex gap-0.5 items-center text-xs text-gray-600 dark:text-gray-500">
 						<div class="">/</div>
 						<input
 							class=" w-full bg-transparent outline-none"

--- a/src/lib/components/workspace/Tools.svelte
+++ b/src/lib/components/workspace/Tools.svelte
@@ -237,7 +237,10 @@
 									<div class="line-clamp-1">
 										{tool.name}
 
-										<span class=" text-gray-600 text-xs font-medium flex-shrink-0">{tool.id}</span>
+										<span
+											class=" text-gray-600 dark:text-gray-500 text-xs font-medium flex-shrink-0"
+											>{tool.id}</span
+										>
 									</div>
 								</div>
 							</Tooltip>
@@ -469,7 +472,7 @@
 			deleteHandler(selectedTool);
 		}}
 	>
-		<div class=" text-sm text-gray-600">
+		<div class=" text-sm text-gray-600 dark:text-gray-500">
 			{$i18n.t('This will delete')} <span class="  font-semibold">{selectedTool.name}</span>.
 		</div>
 	</DeleteConfirmDialog>
@@ -499,7 +502,7 @@
 			reader.readAsText(importFiles[0]);
 		}}
 	>
-		<div class="text-sm text-gray-600">
+		<div class="text-sm text-gray-600 dark:text-gray-500">
 			<div class=" bg-yellow-500/20 text-yellow-700 dark:text-yellow-200 rounded-lg px-4 py-3">
 				<div>{$i18n.t('Please carefully review the following warnings:')}</div>
 

--- a/src/lib/components/workspace/Tools/ToolkitEditor.svelte
+++ b/src/lib/components/workspace/Tools/ToolkitEditor.svelte
@@ -320,7 +320,7 @@ class Tools:
 		submitHandler();
 	}}
 >
-	<div class="text-sm text-gray-600">
+	<div class="text-sm text-gray-600 dark:text-gray-500">
 		<div class=" bg-yellow-500/20 text-yellow-700 dark:text-yellow-200 rounded-lg px-4 py-3">
 			<div>{$i18n.t('Please carefully review the following warnings:')}</div>
 

--- a/src/lib/components/workspace/common/AccessControl.svelte
+++ b/src/lib/components/workspace/common/AccessControl.svelte
@@ -154,7 +154,7 @@
 						{/each}
 					{:else}
 						<div class="flex items-center justify-center">
-							<div class="text-gray-600 text-xs text-center py-2 px-10">
+							<div class="text-gray-600 dark:text-gray-500 text-xs text-center py-2 px-10">
 								{$i18n.t('No groups with access, add a group to grant access')}
 							</div>
 						</div>

--- a/src/routes/(app)/admin/+layout.svelte
+++ b/src/routes/(app)/admin/+layout.svelte
@@ -58,28 +58,28 @@
 						<a
 							class="min-w-fit rounded-full p-1.5 {['/admin/users'].includes($page.url.pathname)
 								? ''
-								: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+								: 'text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'} transition"
 							href="/admin">{$i18n.t('Users')}</a
 						>
 
 						<a
 							class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/admin/evaluations')
 								? ''
-								: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+								: 'text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'} transition"
 							href="/admin/evaluations">{$i18n.t('Evaluations')}</a
 						>
 
 						<a
 							class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/admin/functions')
 								? ''
-								: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+								: 'text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'} transition"
 							href="/admin/functions">{$i18n.t('Functions')}</a
 						>
 
 						<a
 							class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/admin/settings')
 								? ''
-								: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+								: 'text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'} transition"
 							href="/admin/settings">{$i18n.t('Settings')}</a
 						>
 					</div>

--- a/src/routes/(app)/playground/+layout.svelte
+++ b/src/routes/(app)/playground/+layout.svelte
@@ -50,14 +50,14 @@
 							$page.url.pathname
 						)
 							? ''
-							: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+							: 'text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'} transition"
 						href="/playground">{$i18n.t('Chat')}</a
 					>
 
 					<!-- <a
 						class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/playground/notes')
 							? ''
-							: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+							: 'text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'} transition"
 						href="/playground/notes">{$i18n.t('Notes')}</a
 					> -->
 
@@ -66,7 +66,7 @@
 							'/playground/completions'
 						)
 							? ''
-							: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+							: 'text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'} transition"
 						href="/playground/completions">{$i18n.t('Completions')}</a
 					>
 				</div>

--- a/src/routes/(app)/workspace/+layout.svelte
+++ b/src/routes/(app)/workspace/+layout.svelte
@@ -86,7 +86,7 @@
 									'/workspace/models'
 								)
 									? ''
-									: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+									: 'text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'} transition"
 								href="/workspace/models">{$i18n.t('Models')}</a
 							>
 						{/if}
@@ -97,7 +97,7 @@
 									'/workspace/knowledge'
 								)
 									? ''
-									: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+									: 'text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'} transition"
 								href="/workspace/knowledge"
 							>
 								{$i18n.t('Knowledge')}
@@ -110,7 +110,7 @@
 									'/workspace/prompts'
 								)
 									? ''
-									: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+									: 'text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'} transition"
 								href="/workspace/prompts">{$i18n.t('Prompts')}</a
 							>
 						{/if}
@@ -119,7 +119,7 @@
 							<a
 								class="min-w-fit rounded-full p-1.5 {$page.url.pathname.includes('/workspace/tools')
 									? ''
-									: 'text-gray-600 dark:text-gray-600 hover:text-gray-700 dark:hover:text-white'} transition"
+									: 'text-gray-600 dark:text-gray-500 hover:text-gray-700 dark:hover:text-white'} transition"
 								href="/workspace/tools"
 							>
 								{$i18n.t('Tools')}


### PR DESCRIPTION
This corrects timestamp calculation and display to consistently use milliseconds. This change applies to new messages going forward, but does not touch existing seconds-based timestamps in the database (old messages may show the wrong time).

#453