### PR TITLE
Fix timestamps

### DIFF
--- a/src/lib/components/chat/Messages.svelte
+++ b/src/lib/components/chat/Messages.svelte
@@ -251,7 +251,7 @@
 					childrenIds: [],
 					files: undefined,
 					content: content,
-					timestamp: Math.floor(Date.now() / 1000) // Unix epoch
+					timestamp: Date.now() // Unix epoch
 				};
 
 				history.messages[responseMessageId] = responseMessage;

--- a/src/lib/components/chat/Messages/MultiResponseMessages.svelte
+++ b/src/lib/components/chat/Messages/MultiResponseMessages.svelte
@@ -264,7 +264,7 @@
 										<span
 											class=" self-center invisible group-hover:visible text-gray-400 text-xs font-medium uppercase ml-0.5 -mt-0.5"
 										>
-											{dayjs(message.timestamp * 1000).format($i18n.t('h:mm a'))}
+											{dayjs(message.timestamp).format($i18n.t('h:mm a'))}
 										</span>
 									{/if}
 								</Name>

--- a/src/lib/components/chat/Messages/ResponseMessage.svelte
+++ b/src/lib/components/chat/Messages/ResponseMessage.svelte
@@ -506,7 +506,7 @@
 					<span
 						class=" self-center invisible group-hover:visible text-gray-400 text-xs font-medium uppercase ml-0.5 -mt-0.5"
 					>
-						{dayjs(message.timestamp * 1000).format($i18n.t('h:mm a'))}
+						{dayjs(message.timestamp).format($i18n.t('h:mm a'))}
 					</span>
 				{/if}
 			</Name>

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -112,7 +112,7 @@
 						<span
 							class=" invisible group-hover:visible text-gray-400 text-xs font-medium uppercase ml-0.5 -mt-0.5"
 						>
-							{dayjs(message.timestamp * 1000).format($i18n.t('h:mm a'))}
+							{dayjs(message.timestamp).format($i18n.t('h:mm a'))}
 						</span>
 					{/if}
 				</Name>


### PR DESCRIPTION
This corrects timestamp calculation and display to consistently use milliseconds. This change applies to new messages going forward, but does not touch existing seconds-based timestamps in the database (old messages may show the wrong time).

#453 