### PR TITLE
address issue 522, remove inline citation

### DIFF
--- a/backend/open_webui/config.py
+++ b/backend/open_webui/config.py
@@ -1428,7 +1428,7 @@ CHUNK_OVERLAP = PersistentConfig(
 )
 
 DEFAULT_RAG_TEMPLATE = """### Task:
-Respond to the user query using the provided context, incorporating inline citations in the format [source_id] **only when the <source_id> tag is explicitly provided** in the context.
+Respond to the user query using the provided context.
 
 ### Guidelines:
 - If you don't know the answer, clearly state that.
@@ -1436,18 +1436,11 @@ Respond to the user query using the provided context, incorporating inline citat
 - Respond in the same language as the user's query.
 - If the context is unreadable or of poor quality, inform the user and provide the best possible answer.
 - If the answer isn't present in the context but you possess the knowledge, explain this to the user and provide the answer using your own understanding.
-- **Only include inline citations using [source_id] when a <source_id> tag is explicitly provided in the context.**
-- Do not cite if the <source_id> tag is not provided in the context.
+- Do not generate inline citations.
 - Do not use XML tags in your response.
-- Ensure citations are concise and directly related to the information provided.
-
-### Example of Citation:
-If the user asks about a specific topic and the information is found in "whitepaper.pdf" with a provided <source_id>, the response should include the citation like so:
-* "According to the study, the proposed method increases efficiency by 20% [whitepaper.pdf]."
-If no <source_id> is present, the response should omit the citation.
 
 ### Output:
-Provide a clear and direct response to the user's query, including inline citations in the format [source_id] only when the <source_id> tag is present in the context.
+Provide a clear and direct response to the user's query.
 
 <context>
 {{CONTEXT}}
@@ -1457,6 +1450,7 @@ Provide a clear and direct response to the user's query, including inline citati
 {{QUERY}}
 </user_query>
 """
+
 
 RAG_TEMPLATE = PersistentConfig(
     "RAG_TEMPLATE",


### PR DESCRIPTION
# Changelog Entry

### Description

- address issue #522, remove inline citation

### Changed

- removed inline citation from default rag template

---

### Additional Information

For local testing, you can drop the DB and rebuild it, for upper environment, need to update admin settings-->document--> RAG template. 
