### PR TITLE
address file name not get truncated properly issue

### DIFF
--- a/src/lib/components/chat/Messages/Citations.svelte
+++ b/src/lib/components/chat/Messages/Citations.svelte
@@ -113,7 +113,7 @@
 							</div>
 						{/if}
 						<div
-							class="flex-1 mx-1 line-clamp-1 text-black/60 hover:text-black dark:text-white/60 dark:hover:text-white transition"
+							class="flex-1 mx-1 truncate w-full min-w-0 text-black/60 hover:text-black dark:text-white/60 dark:hover:text-white transition"
 						>
 							{citation.source.name}
 						</div>
@@ -145,7 +145,7 @@
 												{idx + 1}
 											</div>
 										{/if}
-										<div class="flex-1 mx-1 line-clamp-1 truncate">
+										<div class="flex-1 mx-1 line-clamp-1 truncate whitespace-normal break-words">
 											{citation.source.name}
 										</div>
 									</button>
@@ -181,7 +181,7 @@
 										{idx + 1}
 									</div>
 								{/if}
-								<div class="flex-1 mx-1 line-clamp-1 truncate">
+								<div class="flex-1 mx-1 line-clamp-1 truncate whitespace-normal break-words">
 									{citation.source.name}
 								</div>
 							</button>

--- a/src/lib/components/chat/Messages/UserMessage.svelte
+++ b/src/lib/components/chat/Messages/UserMessage.svelte
@@ -121,7 +121,7 @@
 
 		<div class="chat-{message.role} w-full min-w-full markdown-prose">
 			{#if message.files}
-				<div class="mt-2.5 mb-1 w-full flex flex-col justify-end overflow-x-auto gap-1 flex-wrap">
+				<div class="mt-2.5 mb-1 w-full flex flex-col justify-end gap-1 flex-wrap">
 					{#each message.files as file}
 						<div class={($settings?.chatBubble ?? true) ? 'self-end' : ''}>
 							{#if file.type === 'image'}

--- a/src/lib/components/common/FileItem.svelte
+++ b/src/lib/components/common/FileItem.svelte
@@ -79,7 +79,7 @@
 
 	{#if !small}
 		<div class="flex flex-col justify-center -space-y-0.5 px-2.5 w-full">
-			<div class=" dark:text-gray-100 text-sm font-medium line-clamp-1 mb-1">
+			<div class=" dark:text-gray-100 text-sm font-medium truncate w-full min-w-0 mb-1">
 				{name}
 			</div>
 


### PR DESCRIPTION
# Changelog Entry

### Description

- address issue #523, adjusted css to handle the long file name truncate

### Screenshots or Videos
<img width="798" alt="image" src="https://github.com/user-attachments/assets/94a270d0-43fa-4cbf-bac3-e1af6d35142b" />


