### PR TITLE
Remove check for localhost token since we are using cookies

### DIFF
--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -169,17 +169,12 @@ async def connect(sid, environ, auth):
 @sio.on("user-join")
 async def user_join(sid, data):
 
-    auth = data["auth"] if "auth" in data else None
-    if not auth or "token" not in auth:
-        return
-    try:
-        data = decode_token(auth["token"])
-    except Exception:
-        return
-    if data is None or "id" not in data:
+    user = data["user"] if "user" in data else None
+    if not user or "id" not in user:
         return
 
-    user = Users.get_user_by_id(data["id"])
+    user = Users.get_user_by_id(user["id"])
+
     if not user:
         return
 

--- a/backend/open_webui/socket/main.py
+++ b/backend/open_webui/socket/main.py
@@ -198,17 +198,11 @@ async def user_join(sid, data):
 
 @sio.on("join-channels")
 async def join_channel(sid, data):
-    auth = data["auth"] if "auth" in data else None
-    if not auth or "token" not in auth:
-        return
-    try:
-        data = decode_token(auth["token"])
-    except Exception:
-        return
-    if data is None or "id" not in data:
+    user = data["user"] if "user" in data else None
+    if not user or "id" not in user:
         return
 
-    user = Users.get_user_by_id(data["id"])
+    user = Users.get_user_by_id(user["id"])
     if not user:
         return
 

--- a/src/lib/components/Auth.svelte
+++ b/src/lib/components/Auth.svelte
@@ -38,8 +38,8 @@
 			if (sessionUser.token) {
 				localStorage.token = sessionUser.token;
 			}
+			$socket.emit('user-join', { user: { id: sessionUser.id } });
 
-			$socket.emit('user-join', { auth: { token: sessionUser.token } });
 			await user.set(sessionUser);
 			await config.set(await getBackendConfig());
 			goto('/');

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -416,7 +416,7 @@
 		});
 
 		if (res) {
-			$socket.emit('join-channels', { auth: { token: $user.token } });
+			$socket.emit('join-channels', { user: { id: $user.id } });
 			await initChannels();
 			showCreateChannel = false;
 		}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -214,8 +214,7 @@
 
 				if (sessionUser) {
 					// Save Session User to Store
-					$socket.emit('user-join', { auth: { token: sessionUser.token } });
-
+					$socket.emit('user-join', { user: { id: sessionUser.id } });
 					$socket?.on('chat-events', chatEventHandler);
 					$socket?.on('channel-events', channelEventHandler);
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -204,30 +204,25 @@
 			if ($config) {
 				await setupSocket($config.features?.enable_websocket ?? true);
 
-				if (localStorage.token) {
-					// Get Session User Info
-					const sessionUser = await getSessionUser().catch((error) => {
-						toast.error(error);
-						return null;
-					});
-
-					if (sessionUser) {
-						// Save Session User to Store
-						$socket.emit('user-join', { auth: { token: sessionUser.token } });
-
-						$socket?.on('chat-events', chatEventHandler);
-						$socket?.on('channel-events', channelEventHandler);
-
-						await user.set(sessionUser);
-						await config.set(await getBackendConfig());
-					} else {
-						// Redirect Invalid Session User to /auth Page
-						localStorage.removeItem('token');
+				// Get Session User Info
+				const sessionUser = await getSessionUser().catch(async (error) => {
+					if ($page.url.pathname !== '/auth') {
 						await goto('/auth');
 					}
+					return null;
+				});
+
+				if (sessionUser) {
+					// Save Session User to Store
+					$socket.emit('user-join', { auth: { token: sessionUser.token } });
+
+					$socket?.on('chat-events', chatEventHandler);
+					$socket?.on('channel-events', channelEventHandler);
+
+					await user.set(sessionUser);
+					await config.set(await getBackendConfig());
 				} else {
-					// Don't redirect if we're already on the auth page
-					// Needed because we pass in tokens from OAuth logins via URL fragments
+					// Redirect Invalid Session User to /auth Page
 					if ($page.url.pathname !== '/auth') {
 						await goto('/auth');
 					}


### PR DESCRIPTION
This fixes an issue causing shared links (i.e. `/s/some_big_uuid`) to not work and some other strangeness. It removes the check for a localhost token since the token is now in the cookie where javascript can not reach it.

`getSessionUser()` should fail when the cookie is not set and redirect to auth.
