### PR TITLE
fix dark mode file name truncate issue for message input

### DIFF
--- a/src/lib/components/common/FileItem.svelte
+++ b/src/lib/components/common/FileItem.svelte
@@ -9,7 +9,7 @@
 	const i18n = getContext('i18n');
 	const dispatch = createEventDispatcher();
 
-	export let className = 'w-60';
+	export let className = 'w-70';
 	export let colorClassName = 'bg-white dark:bg-gray-850 border border-gray-50 dark:border-white/5';
 	export let url: string | null = null;
 


### PR DESCRIPTION
…ssage input

# Changelog Entry

### Description

- found another place that has long file name outside the background issue in dark mode, added to existing ticket #589 

### Fixed

- dark mode issue found in message input file upload



### Screenshots or Videos

- before
<img width="947" alt="image" src="https://github.com/user-attachments/assets/55de913b-32c0-426e-94ca-597ed0233f1d" />

- after:
<img width="409" alt="image" src="https://github.com/user-attachments/assets/af0b0cb4-bedc-4324-b209-822b1aa00317" />

