### PR TITLE

[FEATURE] Add optional embed_type parameter for Cohere semantic search


### DIFF
--- a/backend/open_webui/routers/retrieval.py
+++ b/backend/open_webui/routers/retrieval.py
@@ -770,6 +770,7 @@ def save_docs_to_vector_db(
                 else request.app.state.config.RAG_OLLAMA_API_KEY
             ),
             request.app.state.config.RAG_EMBEDDING_BATCH_SIZE,
+            embed_type="search_document",
         )
 
         embeddings = embedding_function(


### PR DESCRIPTION

# Changelog Entry

### Description

- Enhanced the Cohere embeddings proxy to support explicit embed_type parameter for semantic search, allowing better control over document and query embedding types.

### Added

- Added embed_type parameter support in the Cohere proxy endpoint
- Added documentation for the proxy embeddings endpoint
- Added embed_type parameter propagation through embedding functions

### Changed

- Modified the embedding generation logic to handle embed_type parameter
- Updated the vector database document storage to explicitly use "search_document" embed type
- Refactored the OpenAI batch embeddings function to support additional parameters

### Fixed

- Removed hardcoded input_type logic that was based on input length
- Improved semantic search accuracy by using proper embed types for documents and queries

### Additional Information

- The embed_type parameter accepts "search_document" for storing documents and "search_query" for search queries
- This change improves semantic search accuracy by ensuring proper embedding types are used for different contexts
- The default embed_type remains "search_query" for backward compatibility


_NOTE:_ This PR description was auto-generated. Please review the changes and ensure the description is accurate before merging.