### PR TITLE
Catch and log exceptions when initializing Vertex AI

### DIFF
--- a/backend/open_webui_pipelines/pipelines/google_vertex_manifold_pipeline.py
+++ b/backend/open_webui_pipelines/pipelines/google_vertex_manifold_pipeline.py
@@ -107,11 +107,14 @@ class Pipeline:
                 credentials=credentials,
             )
             model = GenerativeModel("gemini-2.0-flash")
-            response = model.generate_content(
-                "Please respond with 'hi' and nothing else.", stream=False
-            )
-            if "hi" in response.text.lower():
-                logger.debug("Vertex AI client initialized successfully.")
+            try:
+                response = model.generate_content(
+                    "Please respond with 'hi' and nothing else.", stream=False
+                )
+                if "hi" in response.text.lower():
+                    logger.debug("Vertex AI client initialized successfully.")
+            except Exception as e:
+                logger.exception("Vertex AI client failed to initialize.", exc_info=e)
 
     async def on_shutdown(self) -> None:
         """This function is called when the server is stopped."""


### PR DESCRIPTION
The Google Vertex service seems to be having issues right now and the exception it causes is interfering with app startup. This adds some visibility into the exception.