### PR TITLE
Focus first sidebar item when the user opens it using keyboard

### DIFF
--- a/src/lib/components/chat/Navbar.svelte
+++ b/src/lib/components/chat/Navbar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { getContext } from 'svelte';
+	import { getContext, tick } from 'svelte';
 	import { config } from '$lib/stores';
 	import { toast } from 'svelte-sonner';
 
@@ -40,6 +40,16 @@
 
 	let showShareChatModal = false;
 	let showDownloadChatModal = false;
+
+	async function focusFirstChatItem() {
+		// Wait for the DOM to update before focusing the first chat item
+		await tick();
+
+		const firstChatItem = document.getElementById('sidebar-open-toggle-button');
+		if (firstChatItem) {
+			firstChatItem.focus();
+		}
+	};
 </script>
 
 <ShareChatModal bind:show={showShareChatModal} chatId={$chatId} />
@@ -62,6 +72,9 @@
 						class="cursor-pointer px-2 py-2 flex rounded-xl hover:bg-gray-50 dark:hover:bg-gray-850 transition"
 						on:click={() => {
 							showSidebar.set(!$showSidebar);
+
+							// Focus the first chat item when the sidebar is opened.
+							focusFirstChatItem();
 						}}
 						aria-expanded={$showSidebar}
 						aria-label="Toggle Sidebar"

--- a/src/lib/components/chat/Navbar.svelte
+++ b/src/lib/components/chat/Navbar.svelte
@@ -49,7 +49,7 @@
 		if (firstChatItem) {
 			firstChatItem.focus();
 		}
-	};
+	}
 </script>
 
 <ShareChatModal bind:show={showShareChatModal} chatId={$chatId} />

--- a/src/lib/components/layout/Sidebar.svelte
+++ b/src/lib/components/layout/Sidebar.svelte
@@ -450,7 +450,8 @@
 	>
 		<div class="px-1.5 flex justify-between space-x-1 text-gray-600 dark:text-gray-400">
 			<button
-				class=" cursor-pointer p-[7px] flex rounded-xl hover:bg-gray-100 dark:hover:bg-gray-900 transition"
+				id="sidebar-open-toggle-button"
+				class="cursor-pointer p-[7px] flex rounded-xl hover:bg-gray-100 dark:hover:bg-gray-900 transition"
 				on:click={() => {
 					showSidebar.set(!$showSidebar);
 				}}


### PR DESCRIPTION
#685 
**Steps to Test:**

1. Navigate to a page using the keyboard.
2. Trigger the sidebar to open using the Enter.
3. Observe that focus outline moves to the first item inside the sidebar, which is the toggle button to open and close the sidebar.

**Expected Behavior Example:**
https://github.com/user-attachments/assets/6554ff9e-2547-4f9d-be8b-2f101f4863c5

