### PR TITLE
address chat title generation issue

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -298,7 +298,10 @@
 				} else if (type === 'chat:completion') {
 					chatCompletionEventHandler(data, message, event.chat_id);
 				} else if (type === 'chat:title') {
-					chatTitle.set(data);
+					// set chat title based on chat id
+					if (event.chat_id === $chatId) {
+						chatTitle.set(data);
+					}
 					currentChatPage.set(1);
 					await chats.set(await getChatList($currentChatPage));
 				} else if (type === 'chat:tags') {


### PR DESCRIPTION
Address issue #696 , chat title got set wrong on server side. You might not able to recreate the issue locally. Suspect this might be multi pods or multi tab issue, Redis broadcast  to all pods and all user sessions, and one pods have error occur and set other pods chat history title wrong.  

- Update front end chat component to set title based on chat id to avoid set wrong title
- Added fall back title and update the back end generate title part. When there is error occurs, do not use the error as title. Chat history title should be related to user questions and chat conversation. When chat is not complete, default title is New Chat, when chat completed, it will use its content to update the title. If the content is error message, set title to user query. Basically chat title should describe what user want to achieve. 